### PR TITLE
Add opinionated docgen library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+build/
 
 ### Idea ###
 .idea/*

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,15 @@ go 1.13
 
 require (
 	emperror.dev/errors v0.4.2
+	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/banzaicloud/k8s-objectmatcher v1.1.0
 	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/zapr v0.1.0
 	github.com/goph/emperror v0.17.2
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
+	github.com/sergi/go-diff v1.1.0 // indirect
+	go.uber.org/zap v1.9.1
 	k8s.io/api v0.16.4
 	k8s.io/apiextensions-apiserver v0.16.4 // indirect
 	k8s.io/apimachinery v0.16.4

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -22,6 +24,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -244,6 +248,8 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.3/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -265,6 +271,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/docgen/docgen.go
+++ b/pkg/docgen/docgen.go
@@ -1,0 +1,244 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docgen
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	filepath2 "path/filepath"
+	"regexp"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/go-logr/logr"
+)
+
+type DocItem struct {
+	Name                         string
+	SourcePath                   string
+	DestPath                     string
+	Category                     string
+	DefaultValueFromTagExtractor func(string) string
+}
+
+type DocItems []DocItem
+
+type Doc struct {
+	Item        DocItem
+	DisplayName string
+	Content     string
+	Version     string
+	Url         string
+	Desc        string
+	Status      string
+
+	RootNode *ast.File
+	Logger   logr.Logger
+}
+
+func (d *Doc) Append(line string) {
+	if d != nil {
+		d.Content = d.Content + line + "\n"
+	}
+}
+
+func NewDoc(item DocItem, log logr.Logger) *Doc {
+	return &Doc{
+		Item:   item,
+		Logger: log,
+	}
+}
+
+func GetDocumentParser(source DocItem, log logr.Logger) *Doc {
+	fileSet := token.NewFileSet()
+	node, err := parser.ParseFile(fileSet, source.SourcePath, nil, parser.ParseComments)
+	if err != nil {
+		log.Error(err, "Error!")
+	}
+	newDoc := &Doc{
+		Item:     source,
+		RootNode: node,
+		Logger:   log,
+	}
+	return newDoc
+}
+
+func (d *Doc) Generate() error {
+	if d == nil {
+		return nil
+	}
+	if d.RootNode != nil {
+		ast.Inspect(d.RootNode, d.visitNode)
+		d.Logger.V(2).Info("DocumentRoot not present skipping parse")
+	}
+	err := os.MkdirAll(d.Item.DestPath, os.ModePerm)
+	if err != nil {
+		return errors.WrapIf(err, "failed to create destination directory")
+	}
+	filepath := filepath2.Join(d.Item.DestPath, d.Item.Name+".md")
+	f, err := os.Create(filepath)
+	if err != nil {
+		return errors.WrapIf(err, "failed to create destination file")
+	}
+
+	_, err = f.WriteString(d.Content)
+	if err != nil {
+		return errors.WrapIf(errors.WrapIf(f.Close(), "failed to close file"), "failed to write content")
+	}
+
+	return errors.WrapIf(f.Close(), "failed to close file")
+}
+
+func (d *Doc) visitNode(n ast.Node) bool {
+	generic, ok := n.(*ast.GenDecl)
+	if ok {
+		typeName, ok := generic.Specs[0].(*ast.TypeSpec)
+		if ok {
+			_, ok := typeName.Type.(*ast.InterfaceType)
+			if ok && strings.HasPrefix(typeName.Name.Name, "_doc") {
+				d.Append(fmt.Sprintf("# %s", getTypeName(generic, d.Item.Name)))
+				d.Append("## Overview")
+				d.Append(getTypeDocs(generic, false))
+				d.Append("## Configuration")
+			}
+			if ok && strings.HasPrefix(typeName.Name.Name, "_meta") {
+				d.DisplayName = GetPrefixedValue(getTypeDocs(generic, true), `\+name:\"(.*)\"`)
+				d.Url = GetPrefixedValue(getTypeDocs(generic, true), `\+url:\"(.*)\"`)
+				d.Version = GetPrefixedValue(getTypeDocs(generic, true), `\+version:\"(.*)\"`)
+				d.Desc = GetPrefixedValue(getTypeDocs(generic, true), `\+description:\"(.*)\"`)
+				d.Status = GetPrefixedValue(getTypeDocs(generic, true), `\+status:\"(.*)\"`)
+			}
+			if d.DisplayName == "" {
+				d.DisplayName = typeName.Name.Name
+			}
+			if ok && strings.HasPrefix(typeName.Name.Name, "_exp") {
+				d.Append(getTypeDocs(generic, false))
+				d.Append("---")
+			}
+			structure, ok := typeName.Type.(*ast.StructType)
+			if ok {
+				d.Append(fmt.Sprintf("### %s", getTypeName(generic, typeName.Name.Name)))
+				if getTypeDocs(generic, true) != "" {
+					d.Append(fmt.Sprintf("#### %s", getTypeDocs(generic, true)))
+				}
+				d.Append("| Variable Name | Type | Required | Default | Description |")
+				d.Append("|---|---|---|---|---|")
+				for _, item := range structure.Fields.List {
+					name, com, def, required := d.getValuesFromItem(item)
+					d.Append(fmt.Sprintf("| %s | %s | %s | %s | %s |", name, d.normaliseType(item.Type), required, def, com))
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func (d *Doc) normaliseType(fieldType ast.Expr) string {
+	fset := token.NewFileSet()
+	var typeNameBuf bytes.Buffer
+	err := printer.Fprint(&typeNameBuf, fset, fieldType)
+	if err != nil {
+		d.Logger.Error(err, "error getting type")
+	}
+	return typeNameBuf.String()
+}
+
+func GetPrefixedValue(origin, expression string) string {
+	r := regexp.MustCompile(expression)
+	result := r.FindStringSubmatch(origin)
+	if len(result) > 1 {
+		return result[1]
+	}
+	return ""
+}
+
+func getTypeName(generic *ast.GenDecl, defaultName string) string {
+	structName := generic.Doc.Text()
+	result := GetPrefixedValue(structName, `\+docName:\"(.*)\"`)
+	if result != "" {
+		return result
+	}
+	return defaultName
+}
+
+func getTypeDocs(generic *ast.GenDecl, trimSpace bool) string {
+	comment := ""
+	if generic.Doc != nil {
+		for _, line := range generic.Doc.List {
+			newLine := strings.TrimPrefix(line.Text, "//")
+			if trimSpace {
+				newLine = strings.TrimSpace(newLine)
+			}
+			if !strings.HasPrefix(strings.TrimSpace(newLine), "+kubebuilder") &&
+				!strings.HasPrefix(strings.TrimSpace(newLine), "+docName") {
+				comment += newLine + "\n"
+			}
+		}
+	}
+	return comment
+}
+
+func getLink(def string) string {
+	result := GetPrefixedValue(def, `\+docLink:\"(.*)\"`)
+	if result != "" {
+		url := strings.Split(result, ",")
+		def = strings.Replace(def, fmt.Sprintf("+docLink:\"%s\"", result), fmt.Sprintf("[%s](%s)", url[0], url[1]), 1)
+	}
+	return def
+}
+
+func formatRequired(r bool) string {
+	if r {
+		return "Yes"
+	}
+	return "No"
+}
+
+func (d *Doc) getValuesFromItem(item *ast.Field) (name, comment, def, required string) {
+	commentWithDefault := ""
+	if item.Doc != nil {
+		for _, line := range item.Doc.List {
+			newLine := strings.TrimPrefix(line.Text, "//")
+			newLine = strings.TrimSpace(newLine)
+			if !strings.HasPrefix(newLine, "+kubebuilder") {
+				commentWithDefault += newLine + "<br>"
+			}
+		}
+	}
+	tag := item.Tag.Value
+	tagResult := ""
+	if d.Item.DefaultValueFromTagExtractor != nil {
+		tagResult = d.Item.DefaultValueFromTagExtractor(tag)
+	}
+	nameResult := GetPrefixedValue(tag, `json:\"([^,\"]*).*\"`)
+	required = formatRequired(!strings.Contains(GetPrefixedValue(tag, `json:\"(.*)\"`), "omitempty"))
+	if tagResult != "" {
+		return nameResult, getLink(commentWithDefault), tagResult, required
+	}
+	result := GetPrefixedValue(commentWithDefault, `\(default:(.*)\)`)
+	if result != "" {
+		ignore := fmt.Sprintf("(default:%s)", result)
+		comment = strings.Replace(commentWithDefault, ignore, "", 1)
+		return nameResult, comment, getLink(result), required
+	}
+
+	return nameResult, getLink(commentWithDefault), "-", required
+}

--- a/pkg/docgen/docgen_test.go
+++ b/pkg/docgen/docgen_test.go
@@ -1,0 +1,100 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docgen_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/andreyvit/diff"
+	"github.com/banzaicloud/operator-tools/pkg/docgen"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+var logger logr.Logger
+
+func init() {
+	log, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+	logger = zapr.NewLogger(log)
+}
+
+func TestGenParse(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	currentDir := filepath.Dir(filename)
+
+	var testData = []struct {
+		docItem  docgen.DocItem
+		expected string
+	}{
+		{
+			docItem: docgen.DocItem{
+				Name:       "sample",
+				SourcePath: filepath.Join(currentDir, "testdata", "sample.go"),
+				DestPath:   filepath.Join(currentDir, "../../build/_test/docgen"),
+			},
+			expected: heredoc.Doc(`
+				### Sample
+				| Variable Name | Type | Required | Default | Description |
+				|---|---|---|---|---|
+				| field1 | string | No | - |  |
+			`),
+		},
+		{
+			docItem: docgen.DocItem{
+				Name:       "sample-default",
+				SourcePath: filepath.Join(currentDir, "testdata", "sample_default.go"),
+				DestPath:   filepath.Join(currentDir, "../../build/_test/docgen"),
+				DefaultValueFromTagExtractor: func(tag string) string {
+					return docgen.GetPrefixedValue(tag, `asd:\"default:(.*)\"`)
+				},
+			},
+			expected: heredoc.Doc(`
+				### SampleDefault
+				| Variable Name | Type | Required | Default | Description |
+				|---|---|---|---|---|
+				| field1 | string | No | testval |  |
+			`),
+		},
+	}
+
+	for _, item := range testData {
+		parser := docgen.GetDocumentParser(item.docItem, logger)
+		err := parser.Generate()
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		bytes, err := ioutil.ReadFile(filepath.Join(item.docItem.DestPath, item.docItem.Name+".md"))
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if a, e := diff.TrimLinesInString(string(bytes)), diff.TrimLinesInString(item.expected); a != e {
+			t.Errorf("Result does not match (-actual vs +expected):\n%v\nActual: %s", diff.LineDiff(a, e), string(bytes))
+		}
+
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+	}
+}

--- a/pkg/docgen/lister.go
+++ b/pkg/docgen/lister.go
@@ -1,0 +1,120 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docgen
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/go-logr/logr"
+)
+
+type SourceLister struct {
+	Logger                       logr.Logger
+	Sources                      map[string]SourceDir
+	IgnoredSources               []string
+	DefaultValueFromTagExtractor func(string) string
+	Index                        *Doc
+	DocGeneratedHook             func(doc *Doc) error
+	Header                       string
+	Footer                       string
+}
+
+type DocIndex struct {
+	Path string
+}
+
+type SourceDir struct {
+	Path     string
+	DestPath string
+}
+
+func NewSourceLister(sources map[string]SourceDir, logger logr.Logger) *SourceLister {
+	return &SourceLister{
+		Logger:  logger,
+		Sources: sources,
+	}
+}
+
+func (sl *SourceLister) ListSources() ([]DocItem, error) {
+	sourceList := []DocItem{}
+	for category, p := range sl.Sources {
+		files, err := ioutil.ReadDir(p.Path)
+		if err != nil {
+			return nil, errors.WrapIff(err, "failed to read files from %s", p.Path)
+		}
+		for _, file := range files {
+			fname := strings.Replace(file.Name(), ".go", "", 1)
+			if filepath.Ext(file.Name()) == ".go" && sl.IsWhiteListed(fname) {
+				fullPath := filepath.Join(p.Path, file.Name())
+				sourceList = append(sourceList, DocItem{
+					Name:                         fname,
+					SourcePath:                   fullPath,
+					DestPath:                     p.DestPath,
+					DefaultValueFromTagExtractor: sl.DefaultValueFromTagExtractor,
+					Category:                     category,
+				},
+				)
+			}
+		}
+	}
+
+	return sourceList, nil
+}
+
+func (sl *SourceLister) IsWhiteListed(source string) bool {
+	for _, p := range sl.IgnoredSources {
+		r := regexp.MustCompile(p)
+		if r.MatchString(source) {
+			sl.Logger.V(2).Info("ignored source", "source", source)
+			return false
+		}
+	}
+	sl.Logger.V(2).Info("included source", "source", source)
+	return true
+}
+
+func (lister *SourceLister) Generate() error {
+	lister.Index.Append(lister.Header)
+
+	sources, err := lister.ListSources()
+	if err != nil {
+		return errors.WrapIf(err, "failed to get plugin list")
+	}
+
+	for _, source := range sources {
+		document := GetDocumentParser(source, lister.Logger.WithName("docgen"))
+		if err := document.Generate(); err != nil {
+			return err
+		}
+
+		if lister.DocGeneratedHook != nil {
+			if err := lister.DocGeneratedHook(document); err != nil {
+				return err
+			}
+		}
+	}
+
+	lister.Index.Append(lister.Footer)
+
+	if err := lister.Index.Generate(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/docgen/testdata/sample.go
+++ b/pkg/docgen/testdata/sample.go
@@ -1,0 +1,19 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+type Sample struct {
+	Field1 string `json:"field1,omitempty"`
+}

--- a/pkg/docgen/testdata/sample_default.go
+++ b/pkg/docgen/testdata/sample_default.go
@@ -1,0 +1,19 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+type SampleDefault struct {
+	Field1 string `json:"field1,omitempty" asd:"default:testval"`
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Adds document generator library to help generating docs automatically from various go types, for example CRDs.