### PR TITLE
Use emperror.dev/errors instead of emperror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/banzaicloud/k8s-objectmatcher v1.1.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0
-	github.com/goph/emperror v0.17.2
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/sergi/go-diff v1.1.0 // indirect
 	go.uber.org/zap v1.9.1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR removes the deprecated emperror in favor off errors.
