### PR TITLE
Controller ref applier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,18 @@ endif
 
 .PHONY: bin/kubebuilder_$(KUBEBUILDER_VERSION)
 bin/kubebuilder_$(KUBEBUILDER_VERSION):
-	@mkdir -p bin
-	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$(KUBEBUILDER_VERSION)/kubebuilder_$(KUBEBUILDER_VERSION)_$(OS)_amd64.tar.gz | tar xvz -C bin
-	@ln -sf kubebuilder_$(KUBEBUILDER_VERSION)_$(OS)_amd64/bin bin/kubebuilder_$(KUBEBUILDER_VERSION)
+	@if ! test -L bin/kubebuilder_$(KUBEBUILDER_VERSION); \
+		then \
+		mkdir -p bin; \
+		curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$(KUBEBUILDER_VERSION)/kubebuilder_$(KUBEBUILDER_VERSION)_$(OS)_amd64.tar.gz | tar xvz -C bin; \
+		ln -sf kubebuilder_$(KUBEBUILDER_VERSION)_$(OS)_amd64/bin bin/kubebuilder_$(KUBEBUILDER_VERSION); \
+	fi
 
 bin/kubebuilder: bin/kubebuilder_$(KUBEBUILDER_VERSION)
 	@ln -sf kubebuilder_$(KUBEBUILDER_VERSION)/kubebuilder bin/kubebuilder
 	@ln -sf kubebuilder_$(KUBEBUILDER_VERSION)/kube-apiserver bin/kube-apiserver
 	@ln -sf kubebuilder_$(KUBEBUILDER_VERSION)/etcd bin/etcd
 	@ln -sf kubebuilder_$(KUBEBUILDER_VERSION)/kubectl bin/kubectl
-
 
 bin/licensei: bin/licensei-${LICENSEI_VERSION}
 	@ln -sf licensei-${LICENSEI_VERSION} bin/licensei

--- a/pkg/reconciler/native_test.go
+++ b/pkg/reconciler/native_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 )
 
-// FakeResourceOwner object is implements the ResourceOwner interface by piggybacking a ConfigMap (oink-oink)
+// FakeResourceOwner object implements the ResourceOwner interface by piggybacking a ConfigMap (oink-oink)
 type FakeResourceOwner struct {
 	*corev1.ConfigMap
 }

--- a/pkg/reconciler/native_test.go
+++ b/pkg/reconciler/native_test.go
@@ -190,6 +190,31 @@ func TestNativeReconcilerSetNoControllerRefByDefault(t *testing.T) {
 	})
 }
 
+
+func TestNativeReconcilerSetControllerRef(t *testing.T) {
+	nativeReconciler := createReconcilerForRefTests(
+		// without this, controller refs are not going to be applied:
+		reconciler.NativeReconcilerSetControllerRef(),
+	)
+
+	fakeOwnerObject := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "example",
+			Namespace: controlNamespace,
+			UID:       "something-fashionable",
+		},
+	}
+
+	_, err := nativeReconciler.Reconcile(fakeOwnerObject)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	assertConfigMapList(t, func(l *corev1.ConfigMapList) {
+		assert.Len(t, l.Items, 1)
+		assert.Len(t, l.Items[0].OwnerReferences, 1)
+	})
+}
+
 func TestNativeReconcilerSetControllerRefMultipleTimes(t *testing.T) {
 	nativeReconciler := createReconcilerForRefTests(reconciler.NativeReconcilerSetControllerRef())
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Apply a controller ref on objects created by the resource builders. This way the objects will be removed once their owner gets removed.

### TODO
 - [x] Do not put ownerref on CRDs or at least make it configurable