### PR TITLE
Add default 3 to upgrade.MaxHistory

### DIFF
--- a/module/helm/reconciler/reconciler.go
+++ b/module/helm/reconciler/reconciler.go
@@ -320,6 +320,7 @@ func (hr *GenericHelmReconciler) Reconcile(object runtime.Object) (*reconcile.Re
 		upgrade.Namespace = namespace
 		upgrade.Wait = true
 		upgrade.Timeout = time.Minute * 5
+		upgrade.MaxHistory = 3
 		if hr.reconcileHooks != nil {
 			releaseImpl.ConfigureUpgrade(upgrade)
 		}


### PR DESCRIPTION
Default value 0 means unlimited history which can exhaust Kubernetes' secrets.