### PR TITLE
Remove controlNamespace from resourceOwner and various improvements

### DIFF
--- a/docs/types/Readme.md
+++ b/docs/types/Readme.md
@@ -5,7 +5,7 @@ For more information please click on the name
 
 | Name | Description |
 |---|---|
-| **[MetaBase](base_types.md)** |  |
+| **[ObjectKey](base_types.md)** |  |
 | **[Secret](secret_types.md)** | Secret referencing abstraction |
 | **[KubernetesVolume](volume_types.md)** | Kubernetes volume abstraction |
 </center>

--- a/docs/types/base_types.md
+++ b/docs/types/base_types.md
@@ -1,3 +1,8 @@
+### ObjectKey
+| Variable Name | Type | Required | Default | Description |
+|---|---|---|---|---|
+| name | string | No | - |  |
+| namespace | string | No | - |  |
 ### MetaBase
 | Variable Name | Type | Required | Default | Description |
 |---|---|---|---|---|

--- a/pkg/reconciler/component.go
+++ b/pkg/reconciler/component.go
@@ -15,17 +15,23 @@
 package reconciler
 
 import (
+	"emperror.dev/errors"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type ComponentReconciler interface {
 	Reconcile(object runtime.Object) (*reconcile.Result, error)
 	RegisterWatches(*builder.Builder)
+}
+
+type Watches interface {
+	SetupAdditionalWatches(c controller.Controller) error
 }
 
 // Dispatcher orchestrates reconciliation of multiple ComponentReconciler objects
@@ -44,20 +50,20 @@ type Dispatcher struct {
 func (r *Dispatcher) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	object, err := r.ResourceGetter(req)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, errors.WithStack(err)
 	}
 	if r.ResourceFilter != nil {
 		shouldReconcile, err := r.ResourceFilter(object)
 		if err != nil || !shouldReconcile {
-			return reconcile.Result{}, err
+			return reconcile.Result{}, errors.WithStack(err)
 		}
 	}
 	result, err := r.Handle(object)
 	if r.CompletionHandler != nil {
-		return r.CompletionHandler(object, result, err)
+		return r.CompletionHandler(object, result, errors.WithStack(err))
 	}
 	if err != nil {
-		return result, err
+		return result, errors.WithStack(err)
 	}
 	return result, nil
 }
@@ -68,7 +74,12 @@ func (r *Dispatcher) Handle(object runtime.Object) (ctrl.Result, error) {
 	combinedResult := &CombinedResult{}
 	for _, cr := range r.ComponentReconcilers {
 		result, err := cr.Reconcile(object)
-		combinedResult.Combine(result, err)
+		combinedResult.Combine(result, errors.WithStack(err))
+		if cr, ok := cr.(interface{ IsOptional() bool }); ok {
+			if err != nil && !cr.IsOptional() {
+				return combinedResult.Result, combinedResult.Err
+			}
+		}
 	}
 	return combinedResult.Result, combinedResult.Err
 }
@@ -79,4 +90,18 @@ func (r *Dispatcher) RegisterWatches(b *builder.Builder) *builder.Builder {
 		cr.RegisterWatches(b)
 	}
 	return b
+}
+
+// SetupAdditionalWatches dispatches the controller for watch registration to all its components
+func (r *Dispatcher) SetupAdditionalWatches(c controller.Controller) error {
+	for _, cr := range r.ComponentReconcilers {
+		if cr, ok := cr.(Watches); ok {
+			err := cr.SetupAdditionalWatches(c)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/reconciler/component.go
+++ b/pkg/reconciler/component.go
@@ -77,7 +77,7 @@ func (r *Dispatcher) Handle(object runtime.Object) (ctrl.Result, error) {
 		combinedResult.Combine(result, errors.WithStack(err))
 		if cr, ok := cr.(interface{ IsOptional() bool }); ok {
 			if err != nil && !cr.IsOptional() {
-				return combinedResult.Result, combinedResult.Err
+				break
 			}
 		}
 	}

--- a/pkg/reconciler/handlers.go
+++ b/pkg/reconciler/handlers.go
@@ -1,0 +1,33 @@
+package reconciler
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ottypes "github.com/banzaicloud/operator-tools/pkg/types"
+)
+
+func EnqueueByOwnerAnnotationMapper() handler.Mapper {
+	return handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
+		var annotation string
+		var ok bool
+		if annotation, ok = a.Meta.GetAnnotations()[ottypes.BanzaiCloudRelatedTo]; !ok {
+			return []reconcile.Request{}
+		}
+		pieces := strings.SplitN(annotation, string(types.Separator), 2)
+		if len(pieces) != 2 {
+			return []reconcile.Request{}
+		}
+
+		return []reconcile.Request{
+			{NamespacedName: client.ObjectKey{
+				Name:      pieces[1],
+				Namespace: pieces[0],
+			}},
+		}
+	})
+}

--- a/pkg/reconciler/handlers.go
+++ b/pkg/reconciler/handlers.go
@@ -27,12 +27,7 @@ import (
 
 func EnqueueByOwnerAnnotationMapper() handler.Mapper {
 	return handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
-		var annotation string
-		var ok bool
-		if annotation, ok = a.Meta.GetAnnotations()[ottypes.BanzaiCloudRelatedTo]; !ok {
-			return []reconcile.Request{}
-		}
-		pieces := strings.SplitN(annotation, string(types.Separator), 2)
+		pieces := strings.SplitN(a.Meta.GetAnnotations()[ottypes.BanzaiCloudRelatedTo], string(types.Separator), 2)
 		if len(pieces) != 2 {
 			return []reconcile.Request{}
 		}

--- a/pkg/reconciler/handlers.go
+++ b/pkg/reconciler/handlers.go
@@ -1,3 +1,17 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reconciler
 
 import (

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -195,12 +195,11 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 				}
 				if !isCrd {
 					// namespaced resource can only own resources in the same namespace
-					if ownerMeta.GetNamespace() != "" && ownerMeta.GetNamespace() != objectMeta.GetNamespace() {
-						continue
-					}
-					if err := controllerutil.SetControllerReference(ownerMeta, objectMeta, rec.scheme); err != nil {
-						combinedResult.CombineErr(err)
-						continue
+					if ownerMeta.GetNamespace() != "" && ownerMeta.GetNamespace() == objectMeta.GetNamespace() {
+						if err := controllerutil.SetControllerReference(ownerMeta, objectMeta, rec.scheme); err != nil {
+							combinedResult.CombineErr(err)
+							continue
+						}
 					}
 				}
 			}

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -195,7 +195,7 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 				}
 				if !isCrd {
 					// namespaced resource can only own resources in the same namespace
-					if ownerMeta.GetNamespace() != "" && ownerMeta.GetNamespace() == objectMeta.GetNamespace() {
+					if ownerMeta.GetNamespace() == "" || (ownerMeta.GetNamespace() != "" && ownerMeta.GetNamespace() == objectMeta.GetNamespace()) {
 						if err := controllerutil.SetControllerReference(ownerMeta, objectMeta, rec.scheme); err != nil {
 							combinedResult.CombineErr(err)
 							continue

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -194,6 +194,10 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 					isCrd = true
 				}
 				if !isCrd {
+					// namespaced resource can only own resources in the same namespace
+					if ownerMeta.GetNamespace() != "" && ownerMeta.GetNamespace() != objectMeta.GetNamespace() {
+						continue
+					}
 					if err := controllerutil.SetControllerReference(ownerMeta, objectMeta, rec.scheme); err != nil {
 						combinedResult.CombineErr(err)
 						continue

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -212,12 +212,11 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 				}
 				excludeFromPurge[resourceID] = true
 
-				switch state {
-				case StateAbsent:
-					rec.addReconciledObjectState(reconciledObjectState(ReconciledObjectStateAbsent), o.DeepCopyObject())
-				default:
-					rec.addReconciledObjectState(reconciledObjectState(ReconciledObjectStatePresent), o.DeepCopyObject())
+				s := ReconciledObjectStatePresent
+				if state == StateAbsent {
+					s = ReconciledObjectStateAbsent
 				}
+				rec.addReconciledObjectState(s, o.DeepCopyObject())
 			}
 			combinedResult.Combine(result, err)
 		}

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -346,7 +346,7 @@ func (rec *NativeReconciler) purge(excluded map[string]bool, componentId string)
 			if excluded[resourceID] {
 				continue
 			}
-			if objectMeta.GetAnnotations() != nil && objectMeta.GetAnnotations()[types.BanzaiCloudManagedComponent] == componentId {
+			if objectMeta.GetAnnotations()[types.BanzaiCloudManagedComponent] == componentId {
 				rec.Log.Info("pruning unmmanaged resource",
 					"name", objectMeta.GetName(),
 					"namespace", objectMeta.GetNamespace(),
@@ -373,11 +373,7 @@ const (
 )
 
 func (rec *NativeReconciler) initReconciledObjectStates() {
-	rec.reconciledObjectStates = map[reconciledObjectState][]runtime.Object{
-		ReconciledObjectStateAbsent:  make([]runtime.Object, 0),
-		ReconciledObjectStatePresent: make([]runtime.Object, 0),
-		ReconciledObjectStatePurged:  make([]runtime.Object, 0),
-	}
+	rec.reconciledObjectStates = make(map[reconciledObjectState][]runtime.Object)
 }
 
 func (rec *NativeReconciler) addReconciledObjectState(state reconciledObjectState, o runtime.Object) {
@@ -390,6 +386,9 @@ func (rec *NativeReconciler) GetReconciledObjectWithState(state reconciledObject
 
 func (rec *NativeReconciler) addRelatedToAnnotation(objectMeta, ownerMeta metav1.Object) {
 	annotations := objectMeta.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	annotations[types.BanzaiCloudRelatedTo] = utils.ObjectKeyFromObjectMeta(ownerMeta).String()
 	objectMeta.SetAnnotations(annotations)
 }

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -106,7 +106,7 @@ type NativeReconciler struct {
 	scheme                 *runtime.Scheme
 	restMapper             meta.RESTMapper
 	reconciledComponent    NativeReconciledComponent
-	configTranslate        func(runtime.Object) (parent ResourceOwner, config interface{})
+	configTranslate        ResourceTranslate
 	componentName          string
 	setControllerRef       bool
 	reconciledObjectStates map[reconciledObjectState][]runtime.Object

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -43,8 +43,12 @@ type ResourceOwner interface {
 	metav1.Object
 	// to be aware of the owner's type
 	runtime.Object
-	// // control namespace dictates where namespaced objects should belong to
-	// GetControlNamespace() string
+}
+
+type ResourceOwnerWithControlNamespace interface {
+	ResourceOwner
+	// control namespace dictates where namespaced objects should belong to
+	GetControlNamespace() string
 }
 
 type ResourceBuilders func(parent ResourceOwner, object interface{}) []ResourceBuilder

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -195,7 +195,7 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 				}
 				if !isCrd {
 					// namespaced resource can only own resources in the same namespace
-					if ownerMeta.GetNamespace() == "" || (ownerMeta.GetNamespace() != "" && ownerMeta.GetNamespace() == objectMeta.GetNamespace()) {
+					if ownerMeta.GetNamespace() == "" || ownerMeta.GetNamespace() == objectMeta.GetNamespace() {
 						if err := controllerutil.SetControllerReference(ownerMeta, objectMeta, rec.scheme); err != nil {
 							combinedResult.CombineErr(err)
 							continue

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -290,7 +290,7 @@ func (rec *NativeReconciler) generateResourceID(resource runtime.Object) (string
 	return strings.Join(identifiers, "-"), nil
 }
 
-func (rec *NativeReconciler) isGVKExists(gvk schema.GroupVersionKind) bool {
+func (rec *NativeReconciler) gvkExists(gvk schema.GroupVersionKind) bool {
 	if rec.restMapper == nil {
 		return true
 	}

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -304,7 +304,7 @@ func (rec *NativeReconciler) gvkExists(gvk schema.GroupVersionKind) bool {
 	}
 
 	for _, m := range mappings {
-		if reflect.DeepEqual(gvk, m.GroupVersionKind) {
+		if gvk == m.GroupVersionKind {
 			return true
 		}
 	}

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -16,7 +16,6 @@ package reconciler
 
 import (
 	"context"
-	"reflect"
 	"strings"
 
 	"emperror.dev/errors"
@@ -316,7 +315,7 @@ func (rec *NativeReconciler) purge(excluded map[string]bool, componentId string)
 	var allErr error
 	for _, gvk := range rec.reconciledComponent.PurgeTypes() {
 		rec.Log.V(2).Info("purging GVK", "gvk", gvk)
-		if !rec.isGVKExists(gvk) {
+		if !rec.gvkExists(gvk) {
 			continue
 		}
 		objects := &unstructured.UnstructuredList{}

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -22,6 +22,7 @@ import (
 	"emperror.dev/errors"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -350,7 +351,7 @@ func (rec *NativeReconciler) purge(excluded map[string]bool, componentId string)
 					"group", gvk.Group,
 					"version", gvk.Version,
 					"listKind", gvk.Kind)
-				if err := rec.Client.Delete(context.TODO(), &o); err != nil {
+				if err := rec.Client.Delete(context.TODO(), &o); err != nil && !k8serrors.IsNotFound(err) {
 					allErr = errors.Combine(allErr, err)
 				} else {
 					rec.addReconciledObjectState(ReconciledObjectStatePurged, o.DeepCopy())

--- a/pkg/reconciler/native_test.go
+++ b/pkg/reconciler/native_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+
+	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 )
 
 // FakeResourceOwner object implements the ResourceOwner interface by piggybacking a ConfigMap (oink-oink)
@@ -45,6 +46,7 @@ func TestNativeReconcilerKeepsTheSecret(t *testing.T) {
 		k8sClient,
 		reconciler.NewReconciledComponent(
 			func(parent reconciler.ResourceOwner, object interface{}) []reconciler.ResourceBuilder {
+				parentWithControlNamespace := parent.(reconciler.ResourceOwnerWithControlNamespace)
 				rb := []reconciler.ResourceBuilder{}
 				// depending on the incoming config we return 0 or more items
 				count := cast.ToInt(object)
@@ -54,7 +56,7 @@ func TestNativeReconcilerKeepsTheSecret(t *testing.T) {
 						return &corev1.ConfigMap{
 							ObjectMeta: v1.ObjectMeta{
 								Name:      name,
-								Namespace: parent.GetControlNamespace(),
+								Namespace: parentWithControlNamespace.GetControlNamespace(),
 							},
 						}, reconciler.StatePresent, nil
 					})
@@ -64,7 +66,7 @@ func TestNativeReconcilerKeepsTheSecret(t *testing.T) {
 					return &corev1.Secret{
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "keep-the-secret",
-							Namespace: parent.GetControlNamespace(),
+							Namespace: parentWithControlNamespace.GetControlNamespace(),
 						},
 					}, reconciler.StatePresent, nil
 				})
@@ -168,8 +170,8 @@ func TestNativeReconcilerKeepsTheSecret(t *testing.T) {
 
 func TestNativeReconcilerSetNoControllerRefByDefault(t *testing.T) {
 	nativeReconciler := createReconcilerForRefTests(
-		// without this, controller refs are not going to be applied:
-		// reconciler.NativeReconcilerSetControllerRef()
+	// without this, controller refs are not going to be applied:
+	// reconciler.NativeReconcilerSetControllerRef()
 	)
 
 	fakeOwnerObject := &corev1.ConfigMap{
@@ -189,7 +191,6 @@ func TestNativeReconcilerSetNoControllerRefByDefault(t *testing.T) {
 		assert.Len(t, l.Items[0].OwnerReferences, 0)
 	})
 }
-
 
 func TestNativeReconcilerSetControllerRef(t *testing.T) {
 	nativeReconciler := createReconcilerForRefTests(
@@ -267,12 +268,13 @@ func createReconcilerForRefTests(opts ...reconciler.NativeReconcilerOpt) *reconc
 		k8sClient,
 		reconciler.NewReconciledComponent(
 			func(parent reconciler.ResourceOwner, object interface{}) []reconciler.ResourceBuilder {
+				parentWithControlNamespace := parent.(reconciler.ResourceOwnerWithControlNamespace)
 				rb := make([]reconciler.ResourceBuilder, 0)
 				rb = append(rb, func() (object runtime.Object, state reconciler.DesiredState, e error) {
 					return &corev1.ConfigMap{
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "test-cm",
-							Namespace: parent.GetControlNamespace(),
+							Namespace: parentWithControlNamespace.GetControlNamespace(),
 						},
 					}, reconciler.StatePresent, nil
 				})

--- a/pkg/reconciler/native_test.go
+++ b/pkg/reconciler/native_test.go
@@ -251,13 +251,9 @@ func TestNativeReconcilerFailToSetCrossNamespaceControllerRef(t *testing.T) {
 		},
 	}
 
-	expectedErrMsg := "cross-namespace owner references are disallowed"
-
 	_, err := nativeReconciler.Reconcile(fakeOwnerObject)
 	if err != nil {
-		assert.Contains(t, err.Error(), expectedErrMsg)
-	} else {
-		t.Fatalf("expected: %s", "cross-namespace owner references are disallowed")
+		t.Fatalf("got error: %s", err.Error())
 	}
 }
 

--- a/pkg/reconciler/predicates.go
+++ b/pkg/reconciler/predicates.go
@@ -31,7 +31,7 @@ type SkipUpdatePredicate struct {
 	predicate.Funcs
 }
 
-func (SkipCreatePredicate) Update(e event.UpdateEvent) bool {
+func (SkipUpdatePredicate) Update(e event.UpdateEvent) bool {
 	return false
 }
 
@@ -39,6 +39,6 @@ type SkipDeletePredicate struct {
 	predicate.Funcs
 }
 
-func (SkipCreatePredicate) Delete(e event.DeleteEvent) bool {
+func (SkipDeletePredicate) Delete(e event.DeleteEvent) bool {
 	return false
 }

--- a/pkg/reconciler/predicates.go
+++ b/pkg/reconciler/predicates.go
@@ -1,0 +1,30 @@
+package reconciler
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type SkipCreatePredicate struct {
+	predicate.Funcs
+}
+
+func (SkipCreatePredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+type SkipUpdatePredicate struct {
+	predicate.Funcs
+}
+
+func (SkipCreatePredicate) Update(e event.UpdateEvent) bool {
+	return false
+}
+
+type SkipDeletePredicate struct {
+	predicate.Funcs
+}
+
+func (SkipCreatePredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}

--- a/pkg/reconciler/predicates.go
+++ b/pkg/reconciler/predicates.go
@@ -1,3 +1,17 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reconciler
 
 import (

--- a/pkg/reconciler/resource.go
+++ b/pkg/reconciler/resource.go
@@ -270,7 +270,7 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 		}
 
 		debugLog.Info("Updating resource")
-		updateOptions := make([]runtimeClient.UpdateOption, 0)
+		var updateOptions []runtimeClient.UpdateOption
 		if ds, ok := desiredState.(DesiredStateWithUpdateOptions); ok {
 			updateOptions = append(updateOptions, ds.GetUpdateOptions()...)
 		}
@@ -363,7 +363,7 @@ func (r *GenericResourceReconciler) CreateIfNotExist(desired runtime.Object, des
 				}
 			}
 		}
-		createOptions := make([]runtimeClient.CreateOption, 0)
+		var createOptions []runtimeClient.CreateOption
 		if ds, ok := desiredState.(DesiredStateWithCreateOptions); ok {
 			createOptions = append(createOptions, ds.GetCreateOptions()...)
 		}
@@ -434,7 +434,7 @@ func (r *GenericResourceReconciler) delete(desired runtime.Object, desiredState 
 			}
 		}
 	}
-	deleteOptions := make([]runtimeClient.DeleteOption, 0)
+	var deleteOptions []runtimeClient.DeleteOption
 	if ds, ok := desiredState.(DesiredStateWithDeleteOptions); ok {
 		deleteOptions = append(deleteOptions, ds.GetDeleteOptions()...)
 	}

--- a/pkg/reconciler/resource.go
+++ b/pkg/reconciler/resource.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
-	"github.com/banzaicloud/operator-tools/pkg/types"
 )
 
 const (
@@ -46,24 +45,58 @@ const (
 )
 
 type DesiredState interface {
-	BeforeUpdate(object runtime.Object) error
+	BeforeUpdate(current, desired runtime.Object) error
+	BeforeCreate(desired runtime.Object) error
+	BeforeDelete(current runtime.Object) error
+}
+
+type DesiredStateWithDeleteOptions interface {
+	GetDeleteOptions() []runtimeClient.DeleteOption
+}
+
+type DesiredStateWithCreateOptions interface {
+	GetCreateOptions() []runtimeClient.CreateOption
+}
+
+type DesiredStateWithUpdateOptions interface {
+	GetUpdateOptions() []runtimeClient.UpdateOption
+}
+
+type DesiredStateWithStaticState interface {
+	DesiredState() StaticDesiredState
 }
 
 type ResourceReconciler interface {
-	CreateIfNotExist(runtime.Object) (created bool, object runtime.Object, err error)
+	CreateIfNotExist(runtime.Object, DesiredState) (created bool, object runtime.Object, err error)
 	ReconcileResource(runtime.Object, DesiredState) (*reconcile.Result, error)
 }
 
 type StaticDesiredState string
 
-func (s StaticDesiredState) BeforeUpdate(object runtime.Object) error {
+func (s StaticDesiredState) BeforeUpdate(current, desired runtime.Object) error {
+	return nil
+}
+
+func (s StaticDesiredState) BeforeCreate(desired runtime.Object) error {
+	return nil
+}
+
+func (s StaticDesiredState) BeforeDelete(current runtime.Object) error {
 	return nil
 }
 
 type DesiredStateHook func(object runtime.Object) error
 
-func (d DesiredStateHook) BeforeUpdate(object runtime.Object) error {
-	return d(object)
+func (d DesiredStateHook) BeforeUpdate(current, desired runtime.Object) error {
+	return d(current)
+}
+
+func (d DesiredStateHook) BeforeCreate(desired runtime.Object) error {
+	return d(desired)
+}
+
+func (d DesiredStateHook) BeforeDelete(current runtime.Object) error {
+	return d(current)
 }
 
 // GenericResourceReconciler generic resource reconciler
@@ -137,7 +170,7 @@ func NewReconcilerWith(client runtimeClient.Client, opts ...func(reconciler *Rec
 
 // CreateResource creates a resource if it doesn't exist
 func (r *GenericResourceReconciler) CreateResource(desired runtime.Object) error {
-	_, _, err := r.CreateIfNotExist(desired)
+	_, _, err := r.CreateIfNotExist(desired, nil)
 	return err
 }
 
@@ -150,9 +183,13 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 	log := r.resourceLog(desired, resourceDetails...)
 	debugLog := log.V(1)
 	traceLog := log.V(2)
-	switch desiredState {
+	state := desiredState
+	if ds, ok := desiredState.(DesiredStateWithStaticState); ok {
+		state = ds.DesiredState()
+	}
+	switch state {
 	case StateCreated:
-		created, _, err := r.CreateIfNotExist(desired)
+		created, _, err := r.CreateIfNotExist(desired, desiredState)
 		if err == nil && created {
 			return nil, nil
 		}
@@ -160,7 +197,7 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 			return nil, errors.WrapIfWithDetails(err, "failed to create resource", resourceDetails...)
 		}
 	default:
-		created, current, err := r.CreateIfNotExist(desired)
+		created, current, err := r.CreateIfNotExist(desired, desiredState)
 		if err == nil && created {
 			return nil, nil
 		}
@@ -168,42 +205,19 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 			return nil, errors.WrapIfWithDetails(err, "failed to create resource", resourceDetails...)
 		}
 
-		// last chance to hook into the desired state armed with the knowledge of the current state
-		err = desiredState.BeforeUpdate(current)
-		if err != nil {
-			return nil, errors.WrapIfWithDetails(err, "failed to get desired state dynamically", resourceDetails...)
-		}
-
 		if metaObject, ok := current.(metav1.Object); ok {
 			if metaObject.GetDeletionTimestamp() != nil {
 				log.Info(fmt.Sprintf("object %s is being deleted, backing off", metaObject.GetSelfLink()))
 				return &reconcile.Result{RequeueAfter: time.Second * 2}, nil
 			}
-			if !created {
-				if desiredMetaObject, ok := desired.(metav1.Object); ok {
-					base := types.MetaBase{
-						Annotations: desiredMetaObject.GetAnnotations(),
-						Labels:      desiredMetaObject.GetLabels(),
-					}
-					if metaObject, ok := current.DeepCopyObject().(metav1.Object); ok {
-						merged := base.Merge(metav1.ObjectMeta{
-							Labels:      metaObject.GetLabels(),
-							Annotations: metaObject.GetAnnotations(),
-						})
-						desiredMetaObject.SetAnnotations(merged.Annotations)
-						desiredMetaObject.SetLabels(merged.Labels)
-					}
-				}
-
-				if _, ok := metaObject.GetAnnotations()[types.BanzaiCloudManagedComponent]; !ok {
-					if desiredMetaObject, ok := desired.(metav1.Object); ok {
-						a := desiredMetaObject.GetAnnotations()
-						delete(a, types.BanzaiCloudManagedComponent)
-						desiredMetaObject.SetAnnotations(a)
-					}
-				}
-			}
 		}
+
+		// last chance to hook into the desired state armed with the knowledge of the current state
+		err = desiredState.BeforeUpdate(current, desired)
+		if err != nil {
+			return nil, errors.WrapIfWithDetails(err, "failed to get desired state dynamically", resourceDetails...)
+		}
+
 		patchResult, err := patch.DefaultPatchMaker.Calculate(current, desired, patch.IgnoreStatusFields())
 		if err != nil {
 			log.Error(err, "could not match objects")
@@ -234,7 +248,11 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 		}
 
 		debugLog.Info("Updating resource")
-		if err := r.Client.Update(context.TODO(), desired); err != nil {
+		updateOptions := make([]runtimeClient.UpdateOption, 0)
+		if ds, ok := desiredState.(DesiredStateWithUpdateOptions); ok {
+			updateOptions = append(updateOptions, ds.GetUpdateOptions()...)
+		}
+		if err := r.Client.Update(context.TODO(), desired, updateOptions...); err != nil {
 			sErr, ok := err.(*apierrors.StatusError)
 			if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 				if r.Options.EnableRecreateWorkloadOnImmutableFieldChange {
@@ -259,7 +277,7 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 		debugLog.Info("resource updated")
 
 	case StateAbsent:
-		_, err := r.delete(desired)
+		_, err := r.delete(desired, desiredState)
 		if err != nil {
 			return nil, errors.WrapIfWithDetails(err, "failed to delete resource", resourceDetails...)
 		}
@@ -285,7 +303,7 @@ func (r *GenericResourceReconciler) fromDesired(desired runtime.Object) (runtime
 	return reflect.New(reflect.Indirect(reflect.ValueOf(desired)).Type()).Interface().(runtime.Object), nil
 }
 
-func (r *GenericResourceReconciler) CreateIfNotExist(desired runtime.Object) (bool, runtime.Object, error) {
+func (r *GenericResourceReconciler) CreateIfNotExist(desired runtime.Object, desiredState DesiredState) (bool, runtime.Object, error) {
 	current, err := r.fromDesired(desired)
 	if err != nil {
 		return false, nil, errors.WrapIf(err, "failed to create new object based on desired")
@@ -308,7 +326,17 @@ func (r *GenericResourceReconciler) CreateIfNotExist(desired runtime.Object) (bo
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(desired); err != nil {
 			log.Error(err, "Failed to set last applied annotation", "desired", desired)
 		}
-		if err := r.Client.Create(context.TODO(), desired); err != nil {
+		if desiredState != nil {
+			err = desiredState.BeforeCreate(desired)
+			if err != nil {
+				return false, nil, errors.WrapIfWithDetails(err, "failed to prepare desired state before creation", resourceDetails...)
+			}
+		}
+		createOptions := make([]runtimeClient.CreateOption, 0)
+		if ds, ok := desiredState.(DesiredStateWithCreateOptions); ok {
+			createOptions = append(createOptions, ds.GetCreateOptions()...)
+		}
+		if err := r.Client.Create(context.TODO(), desired, createOptions...); err != nil {
 			return false, nil, errors.WrapIfWithDetails(err, "creating resource failed", resourceDetails...)
 		}
 		switch t := desired.DeepCopyObject().(type) {
@@ -331,7 +359,7 @@ func (r *GenericResourceReconciler) CreateIfNotExist(desired runtime.Object) (bo
 	return false, current, nil
 }
 
-func (r *GenericResourceReconciler) delete(desired runtime.Object) (bool, error) {
+func (r *GenericResourceReconciler) delete(desired runtime.Object, desiredState DesiredState) (bool, error) {
 	current, err := r.fromDesired(desired)
 	if err != nil {
 		return false, errors.WrapIf(err, "failed to create new object based on desired")
@@ -360,7 +388,17 @@ func (r *GenericResourceReconciler) delete(desired runtime.Object) (bool, error)
 			return false, nil
 		}
 	}
-	err = r.Client.Delete(context.TODO(), current)
+	if desiredState != nil {
+		err = desiredState.BeforeDelete(current)
+		if err != nil {
+			return false, errors.WrapIfWithDetails(err, "failed to prepare desired state before deletion", resourceDetails...)
+		}
+	}
+	deleteOptions := make([]runtimeClient.DeleteOption, 0)
+	if ds, ok := desiredState.(DesiredStateWithDeleteOptions); ok {
+		deleteOptions = append(deleteOptions, ds.GetDeleteOptions()...)
+	}
+	err = r.Client.Delete(context.TODO(), current, deleteOptions...)
 	if err != nil {
 		return false, errors.WrapIfWithDetails(err, "failed to delete resource", resourceDetails...)
 	}

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -25,7 +25,40 @@ const (
 	VersionLabel   = "app.kubernetes.io/version"
 	ComponentLabel = "app.kubernetes.io/component"
 	ManagedByLabel = "app.kubernetes.io/managed-by"
+
+	BanzaiCloudManagedComponent = "banzaicloud.io/managed-component"
+	BanzaiCloudOwnedBy          = "banzaicloud.io/owned-by"
+	BanzaiCloudRelatedTo        = "banzaicloud.io/related-to"
 )
+
+type ObjectKey struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+type ReconcileStatus string
+
+const (
+	ReconcileStatusCreated     ReconcileStatus = "Created"
+	ReconcileStatusPending     ReconcileStatus = "Pending"
+	ReconcileStatusFailed      ReconcileStatus = "Failed"
+	ReconcileStatusReconciling ReconcileStatus = "Reconciling"
+	ReconcileStatusAvailable   ReconcileStatus = "Available"
+	ReconcileStatusSucceeded   ReconcileStatus = "Succeeded"
+	ReconcileStatusUnmanaged   ReconcileStatus = "Unmanaged"
+)
+
+func (s ReconcileStatus) Available() bool {
+	return s == ReconcileStatusAvailable || s == ReconcileStatusSucceeded
+}
+
+func (s ReconcileStatus) Failed() bool {
+	return s == ReconcileStatusFailed
+}
+
+func (s ReconcileStatus) Pending() bool {
+	return s == ReconcileStatusCreated || s == ReconcileStatusReconciling || s == ReconcileStatusPending
+}
 
 // +kubebuilder:object:generate=true
 

--- a/pkg/utils/sort.go
+++ b/pkg/utils/sort.go
@@ -101,6 +101,8 @@ func (os RuntimeObjects) InstallObjectOrder() func(o runtime.Object) int {
 		"CronJob",
 		"Ingress",
 		"APIService",
+		"ValidatingWebhookConfiguration",
+		"MutatingWebhookConfiguration",
 	}
 
 	order := make(map[string]int, len(Order))

--- a/pkg/utils/sort.go
+++ b/pkg/utils/sort.go
@@ -1,0 +1,173 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type RuntimeObjects []runtime.Object
+type ResourceOrder string
+type ResourceScoreFunc func(o runtime.Object) int
+
+const (
+	InstallResourceOrder   ResourceOrder = "Install"
+	UninstallResourceOrder ResourceOrder = "Uninstall"
+)
+
+func (os RuntimeObjects) Sort(order ResourceOrder) {
+	var score ResourceScoreFunc
+
+	switch order {
+	case InstallResourceOrder:
+		score = os.InstallObjectOrder()
+	case UninstallResourceOrder:
+		score = os.UninstallObjectOrder()
+	default:
+		score = func(o runtime.Object) int { return 0 }
+	}
+
+	sort.Slice(os, func(i, j int) bool {
+		iScore := score(os[i])
+		jScore := score(os[j])
+		iGVK := os[i].GetObjectKind().GroupVersionKind()
+		jGVK := os[j].GetObjectKind().GroupVersionKind()
+		var iName, jName string
+		if o, ok := os[i].(metav1.Object); ok {
+			iName = o.GetName()
+		}
+		if o, ok := os[j].(metav1.Object); ok {
+			jName = o.GetName()
+		}
+		return iScore < jScore ||
+			(iScore == jScore &&
+				iGVK.Group < jGVK.Group) ||
+			(iScore == jScore &&
+				iGVK.Group == jGVK.Group &&
+				iGVK.Kind < os[j].GetObjectKind().GroupVersionKind().Kind) ||
+			(iScore == jScore &&
+				iGVK.Group == jGVK.Group &&
+				iGVK.Kind == jGVK.Kind &&
+				iName < jName)
+	})
+}
+
+func (os RuntimeObjects) InstallObjectOrder() func(o runtime.Object) int {
+	var Order = []string{
+		"CustomResourceDefinition",
+		"Namespace",
+		"ResourceQuota",
+		"LimitRange",
+		"PodSecurityPolicy",
+		"PodDisruptionBudget",
+		"Secret",
+		"ConfigMap",
+		"StorageClass",
+		"PersistentVolume",
+		"PersistentVolumeClaim",
+		"ServiceAccount",
+		"ClusterRole",
+		"ClusterRoleList",
+		"ClusterRoleBinding",
+		"ClusterRoleBindingList",
+		"Role",
+		"RoleList",
+		"RoleBinding",
+		"RoleBindingList",
+		"Service",
+		"DaemonSet",
+		"Pod",
+		"ReplicationController",
+		"ReplicaSet",
+		"Deployment",
+		"HorizontalPodAutoscaler",
+		"StatefulSet",
+		"Job",
+		"CronJob",
+		"Ingress",
+		"APIService",
+	}
+
+	order := make(map[string]int, len(Order))
+	for i, kind := range Order {
+		order[kind] = i
+	}
+
+	return func(o runtime.Object) int {
+		if nr, ok := order[o.GetObjectKind().GroupVersionKind().Kind]; ok {
+			return nr
+		}
+		return 1000
+	}
+}
+
+func (os RuntimeObjects) UninstallObjectOrder() func(o runtime.Object) int {
+	var Order = []string{
+		"Policy",
+		"Gateway",
+		"VirtualService",
+		"DestinationRule",
+		"Handler",
+		"Instance",
+		"Rule",
+		"APIService",
+		"Ingress",
+		"Service",
+		"CronJob",
+		"Job",
+		"StatefulSet",
+		"HorizontalPodAutoscaler",
+		"Deployment",
+		"ReplicaSet",
+		"ReplicationController",
+		"Pod",
+		"DaemonSet",
+		"RoleBindingList",
+		"RoleBinding",
+		"RoleList",
+		"Role",
+		"ClusterRoleBindingList",
+		"ClusterRoleBinding",
+		"ClusterRoleList",
+		"ClusterRole",
+		"ServiceAccount",
+		"PersistentVolumeClaim",
+		"PersistentVolume",
+		"StorageClass",
+		"ConfigMap",
+		"Secret",
+		"PodDisruptionBudget",
+		"PodSecurityPolicy",
+		"LimitRange",
+		"ResourceQuota",
+		"Namespace",
+		"CustomResourceDefinition",
+	}
+
+	order := make(map[string]int, len(Order))
+	for i, kind := range Order {
+		order[kind] = i
+	}
+
+	return func(o runtime.Object) int {
+		if nr, ok := order[o.GetObjectKind().GroupVersionKind().Kind]; ok {
+			return nr
+		}
+		return 0
+	}
+}

--- a/pkg/utils/sort.go
+++ b/pkg/utils/sort.go
@@ -120,6 +120,8 @@ func (os RuntimeObjects) InstallObjectOrder() func(o runtime.Object) int {
 
 func (os RuntimeObjects) UninstallObjectOrder() func(o runtime.Object) int {
 	var Order = []string{
+		"MutatingWebhookConfiguration",
+		"ValidatingWebhookConfiguration",
 		"Policy",
 		"Gateway",
 		"VirtualService",

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -36,6 +36,38 @@ func MergeLabels(labelGroups ...map[string]string) map[string]string {
 	return mergedLabels
 }
 
+func PointerToBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+
+	return *b
+}
+
+func PointerToUint(i *uint) uint {
+	if i == nil {
+		return 0
+	}
+
+	return *i
+}
+
+func PointerToInt(i *int) int {
+	if i == nil {
+		return 0
+	}
+
+	return *i
+}
+
+func PointerToString(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
+}
+
 // IntPointer converts int32 to *int32
 func IntPointer(i int32) *int32 {
 	return &i


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- Removes `GetControlNamespace` from the `ResourceOwner` interface while providing an alternative as `ResourceOwnerWithControlNamespace` for compatibility with legacy clients
- Exiting from the `Dispatcher` after a `ComponentReconciler` fails is now optional per component
- Owners can now be declared as custom annotations so that we know which resources we are allowed to manage and purge
- Collect reconciled objects and their desired states to be able to wait for them externally
- Introduce `Created` state for desired states to detect where we don't want to actively manage an object, just create it if it doesn't exist
- Introduce various desired state hooks for more flexibility with resource reconciliation special cases
- Add generic object ordering helpers