### PR TITLE
Process requirements.yaml for backwards compatibility with legacy charts

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -129,6 +129,11 @@ func getFiles(fs http.FileSystem) ([]*loader.BufferedFile, error) {
 		{
 			Name: chartutil.ChartfileName,
 		},
+		{
+			// Without requirements.yaml legacy charts's subdependencies will be processed but cannot be disabled
+			// See https://github.com/helm/helm/blob/e2442699fa4703456b16884990c5218c16ed16fc/pkg/chart/loader/load.go#L105
+			Name: "requirements.yaml",
+		},
 	}
 
 	// if the Helm chart templates use some resource files (like dashboards), those should be put under resources


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Process requirements.yaml for backwards compatibility with legacy charts. 


### Why?
Without requirements.yaml helm3 won't be able to figure out which chart should be disabled.
