### PR TITLE
Status handling, logging and helm resource cleanup improvements

### DIFF
--- a/pkg/helm/templatereconciler/reconciler.go
+++ b/pkg/helm/templatereconciler/reconciler.go
@@ -104,7 +104,7 @@ func (rec *HelmReconciler) Reconcile(object runtime.Object, component Component)
 		}
 	}
 
-	defer logger.EnableGroupSession(rec.logger)
+	defer logger.EnableGroupSession(rec.logger)()
 
 	rec.logger.Info("syncing resources")
 

--- a/pkg/reconciler/predicates.go
+++ b/pkg/reconciler/predicates.go
@@ -58,6 +58,12 @@ func (PendingStatusPredicate) Update(e event.UpdateEvent) bool {
 		return o.IsAnyInState(types.ReconcileStatusPending)
 	}
 
+	if o, ok := e.ObjectNew.(interface {
+		IsPending() bool
+	}); ok {
+		return o.IsPending()
+	}
+
 	return false
 }
 

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -39,14 +39,28 @@ type ObjectKey struct {
 type ReconcileStatus string
 
 const (
-	ReconcileStatusCreated     ReconcileStatus = "Created"
-	ReconcileStatusPending     ReconcileStatus = "Pending"
+	// Used for components and for aggregated status
 	ReconcileStatusFailed      ReconcileStatus = "Failed"
+
+	// Used for components and for aggregated status
 	ReconcileStatusReconciling ReconcileStatus = "Reconciling"
+
+	// Used for components
 	ReconcileStatusAvailable   ReconcileStatus = "Available"
-	ReconcileStatusSucceeded   ReconcileStatus = "Succeeded"
 	ReconcileStatusUnmanaged   ReconcileStatus = "Unmanaged"
+	ReconcileStatusRemoved     ReconcileStatus = "Removed"
+
+	// Used for aggregated status if all the components are stableized (Available, Unmanaged or Removed)
+	ReconcileStatusSucceeded   ReconcileStatus = "Succeeded"
+
+	// Used to trigger reconciliation for a resource that otherwise ignores status changes, but listens to the Pending state
+	// See PendingStatusPredicate in pkg/reconciler
+	ReconcileStatusPending     ReconcileStatus = "Pending"
 )
+
+func (s ReconcileStatus) Stable() bool {
+	return s == ReconcileStatusUnmanaged || s == ReconcileStatusRemoved || s == ReconcileStatusAvailable
+}
 
 func (s ReconcileStatus) Available() bool {
 	return s == ReconcileStatusAvailable || s == ReconcileStatusSucceeded
@@ -57,7 +71,33 @@ func (s ReconcileStatus) Failed() bool {
 }
 
 func (s ReconcileStatus) Pending() bool {
-	return s == ReconcileStatusCreated || s == ReconcileStatusReconciling || s == ReconcileStatusPending
+	return s == ReconcileStatusReconciling || s == ReconcileStatusPending
+}
+
+// Computes an aggregated state based on component statuses
+func AggregatedState(componentStatuses []ReconcileStatus) ReconcileStatus {
+	overallStatus := ReconcileStatusReconciling
+	statusMap := make(map[ReconcileStatus]bool)
+	hasUnstable := false
+	for _, cs := range componentStatuses {
+		if cs != "" {
+			statusMap[cs] = true
+		}
+		if !(cs == "" || cs.Stable()) {
+			hasUnstable = true
+		}
+	}
+
+	if statusMap[ReconcileStatusFailed] {
+		overallStatus = ReconcileStatusFailed
+	} else if statusMap[ReconcileStatusReconciling] {
+		overallStatus = ReconcileStatusReconciling
+	}
+
+	if !hasUnstable {
+		overallStatus = ReconcileStatusSucceeded
+	}
+	return overallStatus
 }
 
 // +kubebuilder:object:generate=true


### PR DESCRIPTION
- Add aggregated status function
- Make status information more relevant in helm template reconciler
- Remove created status
- Fix helm template reconciler's log grouping
- Upgrade logger with latest changes based on backyards
- Remove orphaned pods left from removed jobs after all resources have been removed