### PR TITLE
Status aware components, OnFinish notification

### DIFF
--- a/pkg/reconciler/component.go
+++ b/pkg/reconciler/component.go
@@ -105,7 +105,7 @@ func (r *Dispatcher) Handle(object runtime.Object) (ctrl.Result, error) {
 					combinedResult.CombineErr(errors.WrapIf(uerr, "unable to update status for component"))
 				}
 			} else {
-				if result == nil || result.Requeue == false && result.RequeueAfter == 0 {
+				if result == nil || (!result.Requeue && result.RequeueAfter == 0) {
 					if cr.IsEnabled(object) {
 						if uerr := cr.Update(object, types.ReconcileStatusAvailable, ""); uerr != nil {
 							combinedResult.CombineErr(errors.WrapIf(uerr, "unable to update status for component"))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Introduces a new interface that components may implement in case they want to implement status reporting backed by their dispatcher. 

Another interface is introduced to receive an event when a component's reconciliation have been finished and can decide what to do with it.
