### PR TITLE
Secret loader improvement

### DIFF
--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -28,7 +28,7 @@ type SecretLoader interface {
 	Load(secret *Secret) (string, error)
 }
 
-func NewSecretLoader(client client.Client, namespace, mountPath string, secrets *MountSecrets) SecretLoader {
+func NewSecretLoader(client client.Reader, namespace, mountPath string, secrets *MountSecrets) SecretLoader {
 	return &secretLoader{
 		client:    client,
 		mountPath: mountPath,
@@ -61,7 +61,7 @@ type secretLoader struct {
 	// secretLoader is limited to a single namespace, to avoid hijacking other namespace's secrets
 	namespace string
 	mountPath string
-	client    client.Client
+	client    client.Reader
 	secrets   *MountSecrets
 }
 

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -28,13 +28,16 @@ type SecretLoader interface {
 	Load(secret *Secret) (string, error)
 }
 
-type secretLoader struct {
-	// secretLoader is limited to a single namespace, to avoid hijacking other namespace's secrets
-	namespace string
-	mountPath string
-	client    client.Client
-	secrets   *MountSecrets
+func NewSecretLoader(client client.Client, namespace, mountPath string, secrets *MountSecrets) SecretLoader {
+	return &secretLoader{
+		client:    client,
+		mountPath: mountPath,
+		namespace: namespace,
+		secrets:   secrets,
+	}
 }
+
+type MountSecrets []MountSecret
 
 func (m *MountSecrets) Append(namespace string, secret *corev1.SecretKeySelector, mappedKey string, value []byte) {
 	*m = append(*m, MountSecret{
@@ -46,8 +49,6 @@ func (m *MountSecrets) Append(namespace string, secret *corev1.SecretKeySelector
 	})
 }
 
-type MountSecrets []MountSecret
-
 type MountSecret struct {
 	Namespace string
 	Name      string
@@ -56,13 +57,12 @@ type MountSecret struct {
 	Value     []byte
 }
 
-func NewSecretLoader(client client.Client, namespace, mountPath string, secrets *MountSecrets) SecretLoader {
-	return &secretLoader{
-		client:    client,
-		mountPath: mountPath,
-		namespace: namespace,
-		secrets:   secrets,
-	}
+type secretLoader struct {
+	// secretLoader is limited to a single namespace, to avoid hijacking other namespace's secrets
+	namespace string
+	mountPath string
+	client    client.Client
+	secrets   *MountSecrets
 }
 
 func (k *secretLoader) Load(secret *Secret) (string, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Reduce size of secret loader's client's required interface.

### Why?
The secret loader implementation only uses the `Get` method of the `sigs.k8s.io/controller-runtime/pkg/client.Client` interface so the required type — thus the dependency's required type — could be reduced to an interface with only that method, but to keep the code simple the existing `sigs.k8s.io/controller-runtime/pkg/client.Reader` type is a good compromise.
