### PR TITLE
Do not mutate object state in the SpecChangePredicate

### DIFF
--- a/pkg/reconciler/predicates.go
+++ b/pkg/reconciler/predicates.go
@@ -72,7 +72,10 @@ type SpecChangePredicate struct {
 }
 
 func (SpecChangePredicate) Update(e event.UpdateEvent) bool {
-	e.MetaNew.SetResourceVersion(e.MetaOld.GetResourceVersion())
+	oldRV := e.MetaOld.GetResourceVersion()
+	e.MetaOld.SetResourceVersion(e.MetaNew.GetResourceVersion())
+	defer e.MetaOld.SetResourceVersion(oldRV)
+
 	patchResult, err := patch.DefaultPatchMaker.Calculate(e.ObjectOld, e.ObjectNew, patch.IgnoreStatusFields(), IgnoreManagedFields())
 	if err != nil {
 		return true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Avoids mutating the metadata of "new" objects which is essentially our cache. 

### Why?
Mutating the cache can cause unexpected behaviour for example when trying to update an object which has an outdated resourceversion set.