### PR TITLE
Avoid setting an ownerref on namespaces

### DIFF
--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -263,14 +263,16 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 			}
 			rec.addRelatedToAnnotation(objectMeta, ownerMeta)
 			if rec.setControllerRef {
-				isCrd := false
+				skipControllerRef := false
 				switch o.(type) {
 				case *v1beta1.CustomResourceDefinition:
-					isCrd = true
+					skipControllerRef = true
 				case *v1.CustomResourceDefinition:
-					isCrd = true
+					skipControllerRef = true
+				case *corev1.Namespace:
+					skipControllerRef = true
 				}
-				if !isCrd {
+				if !skipControllerRef {
 					// namespaced resource can only own resources in the same namespace
 					if ownerMeta.GetNamespace() == "" || ownerMeta.GetNamespace() == objectMeta.GetNamespace() {
 						if err := controllerutil.SetControllerReference(ownerMeta, objectMeta, rec.scheme); err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Avoid setting an ownerref on Namespace resources.

### Why?
Setting ownerref, thus accidentally removing namespaces is something that is unexpected and should be avoided. Even if there is a valid scenario for that, it should be supported in a different way.

