### PR TITLE
Append non-template CRD objects

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -549,6 +549,7 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
+github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/helm/render_test.go
+++ b/pkg/helm/render_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRenderChartWithCrdsAndTemplates(t *testing.T) {
+	chart := http.Dir("testdata/crds-and-templates/logging-operator")
+
+	defaultValues, err := GetDefaultValues(chart)
+	require.NoError(t, err)
+
+	valuesMap := map[string]interface{}{}
+	err = yaml.Unmarshal(defaultValues, &valuesMap)
+	require.NoError(t, err)
+
+	// custom resources in templates must be disabled explicitly
+	valuesMap["createCustomResource"] = false
+
+	objects, err := Render(chart, valuesMap, ReleaseOptions{
+		Name:      "release-name",
+		Namespace: "release-namespace",
+	}, "logging-operator")
+	require.NoError(t, err)
+
+	assert.Len(t, objects, 1)
+
+	o, ok := objects[0].(*unstructured.Unstructured)
+	assert.True(t, ok, "object should be unstructured")
+
+	assert.Equal(t, "loggings.logging.banzaicloud.io", o.GetName())
+}
+
+
+func TestRenderChartWithCrdsOnly(t *testing.T) {
+	chart := http.Dir("testdata/crds-only/logging-operator")
+
+	defaultValues, err := GetDefaultValues(chart)
+	require.NoError(t, err)
+
+	valuesMap := map[string]interface{}{}
+	err = yaml.Unmarshal(defaultValues, &valuesMap)
+	require.NoError(t, err)
+
+	objects, err := Render(chart, valuesMap, ReleaseOptions{
+		Name:      "release-name",
+		Namespace: "release-namespace",
+	}, "logging-operator")
+	require.NoError(t, err)
+
+	assert.Len(t, objects, 1)
+
+	o, ok := objects[0].(*unstructured.Unstructured)
+	assert.True(t, ok, "object should be unstructured")
+
+	assert.Equal(t, "loggings.logging.banzaicloud.io", o.GetName())
+}

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/.helmignore
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/Chart.yaml
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "3.7.1"
+description: A Helm chart to install Banzai Cloud logging-operator
+name: logging-operator
+version: 3.7.1

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/README.md
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/README.md
@@ -1,0 +1,129 @@
+
+# Logging operator Chart
+
+[Logging operator](https://github.com/banzaicloud/logging-operator) Managed centralized logging component fluentd and fluent-bit instance on cluster.
+
+## tl;dr:
+
+```bash
+$ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
+$ helm repo update
+$ helm install banzaicloud-stable/logging-operator
+```
+
+## Introduction
+
+This chart bootstraps a [Logging Operator](https://github.com/banzaicloud/logging-operator) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release banzaicloud-stable/logging-operator
+```
+
+### CRDs
+Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs from the `crds` folder and from templates at the same time.
+
+The command deploys **Logging operator** on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the logging-operator chart and their default values.
+
+|                      Parameter                      |                        Description                     |             Default            |
+| --------------------------------------------------- | ------------------------------------------------------ | ------------------------------ |
+| `image.repository`                                  | Container image repository                             | `ghcr.io/banzaicloud/logging-operator` |
+| `image.tag`                                         | Container image tag                                    | `3.7.1`                        |
+| `image.pullPolicy`                                  | Container pull policy                                  | `IfNotPresent`                 |
+| `nameOverride`                                      | Override name of app                                   | ``                             |
+| `fullnameOverride`                                  | Override full name of app                              | ``                             |
+| `namespaceOverride`                                 | Override namespace of app                              | ``                             |
+| `watchNamespace`                                    | Namespace to watch for LoggingOperator CRD             | ``                             |
+| `rbac.enabled`                                      | Create rbac service account and roles                  | `true`                         |
+| `rbac.psp.enabled`                                  | Must be used with `rbac.enabled` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled.    | `false`                        |
+| `priorityClassName`                                 | Operator priorityClassName                             | `{}`                           |
+| `affinity`                                          | Node Affinity                                          | `{}`                           |
+| `resources`                                         | CPU/Memory resource requests/limits                    | `{}`                           |
+| `tolerations`                                       | Node Tolerations                                       | `[]`                           |
+| `nodeSelector`                                      | Define which Nodes the Pods are scheduled on.          | `{}`                           |
+| `annotations`                                       | Define annotations for logging-operator pods           | `{}`                           |
+| `podSecurityContext`                                | Pod SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/)                                                                                             | `{"runAsNonRoot": true, "runAsUser": 1000, "fsGroup": 2000}` |
+| `securityContext`                                   | Container SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) | `{"allowPrivilegeEscalation": false, "readOnlyRootFilesystem": true}` |
+| `createCustomResource`                              | Create CRDs. | `true` |
+| `monitoring.serviceMonitor.enabled`                 | Create Prometheus Operator servicemonitor. | `false` |
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+
+```bash
+$ helm install --name my-release -f values.yaml banzaicloud-stable/logging-operator
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Installing Fluentd and Fluent-bit via logging
+
+The previous chart does **not** install `logging` resource to deploy Fluentd and Fluent-bit on cluster. To install them please use the [Logging Operator Logging](https://github.com/banzaicloud/logging-operator/tree/master/charts/logging-operator-logging) chart.
+
+## tl;dr:
+
+```bash
+$ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
+$ helm repo update
+$ helm install banzaicloud-stable/logging-operator-logging
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the logging-operator-logging chart and their default values.
+## tl;dr:
+
+```bash
+$ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
+$ helm repo update
+$ helm install banzaicloud-stable/logging-operator-logging
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the logging-operator-logging chart and their default values.
+
+|                      Parameter                      |                        Description                     |             Default            |
+| --------------------------------------------------- | ------------------------------------------------------ | ------------------------------ |
+| `tls.enabled`                                       | Enabled TLS communication between components           | true                           |
+| `tls.fluentdSecretName`                                    | Specified secret name, which contain tls certs         | This will overwrite automatic Helm certificate generation. |
+| `tls.fluentbitSecretName`                                    | Specified secret name, which contain tls certs         | This will overwrite automatic Helm certificate generation. |
+| `tls.sharedKey`                                     | Shared key between nodes (fluentd-fluentbit)           | [autogenerated]                |
+| `fluentbit.enabled`                                 | Install fluent-bit                                     | true                           |
+| `fluentbit.namespace`                               | Specified fluentbit installation namespace             | same as operator namespace     |
+| `fluentbit.image.tag`                               | Fluentbit container image tag                          | `1.6.1`                        |
+| `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`            |
+| `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                 |
+| `fluentd.enabled`                                   | Install fluentd                                        | true                           |
+| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.11.4-alpine-1`              |
+| `fluentd.image.repository`                          | Fluentd container image repository                     | `ghcr.io/banzaicloud/fluentd`          |
+| `fluentd.image.pullPolicy`                          | Fluentd container pull policy                          | `IfNotPresent`                 |
+| `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag             | `latest`                       |
+| `fluentd.volumeModImage.repository`                 | Fluentd volumeModImage container image repository      | `busybox`                      |
+| `fluentd.volumeModImage.pullPolicy`                 | Fluentd volumeModImage container pull policy           | `IfNotPresent`                 |
+| `fluentd.configReloaderImage.tag`                   | Fluentd configReloaderImage container image tag        | `v0.2.2`                       |
+| `fluentd.configReloaderImage.repository`            | Fluentd configReloaderImage container image repository | `jimmidyson/configmap-reload`  |
+| `fluentd.configReloaderImage.pullPolicy`            | Fluentd configReloaderImage container pull policy      | `IfNotPresent`                 |
+| `fluentd.fluentdPvcSpec.accessModes`                | Fluentd persistence volume access modes                | `[ReadWriteOnce]`              |
+| `fluentd.fluentdPvcSpec.resources.requests.storage` | Fluentd persistence volume size                        | `21Gi`                         |
+| `fluentd.fluentdPvcSpec.storageClassName`           | Fluentd persistence volume storageclass                | `"""`                          |

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1,0 +1,2539 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: loggings.logging.banzaicloud.io
+spec:
+  group: logging.banzaicloud.io
+  names:
+    categories:
+    - logging-all
+    kind: Logging
+    listKind: LoggingList
+    plural: loggings
+    singular: logging
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allowClusterResourcesFromAllNamespaces:
+              type: boolean
+            controlNamespace:
+              type: string
+            defaultFlow:
+              properties:
+                filters:
+                  items:
+                    properties:
+                      concat:
+                        properties:
+                          continuous_line_regexp:
+                            type: string
+                          flush_interval:
+                            type: integer
+                          keep_partial_key:
+                            type: boolean
+                          keep_partial_metadata:
+                            type: string
+                          key:
+                            type: string
+                          multiline_end_regexp:
+                            type: string
+                          multiline_start_regexp:
+                            type: string
+                          n_lines:
+                            type: integer
+                          partial_key:
+                            type: string
+                          partial_value:
+                            type: string
+                          separator:
+                            type: string
+                          stream_identity_key:
+                            type: string
+                          timeout_label:
+                            type: string
+                          use_first_timestamp:
+                            type: boolean
+                          use_partial_metadata:
+                            type: string
+                        type: object
+                      dedot:
+                        properties:
+                          de_dot_nested:
+                            type: boolean
+                          de_dot_separator:
+                            type: string
+                        type: object
+                      detectExceptions:
+                        properties:
+                          languages:
+                            items:
+                              type: string
+                            type: array
+                          max_bytes:
+                            type: integer
+                          max_lines:
+                            type: integer
+                          message:
+                            type: string
+                          multiline_flush_interval:
+                            type: string
+                          remove_tag_prefix:
+                            type: string
+                          stream:
+                            type: string
+                        type: object
+                      geoip:
+                        properties:
+                          backend_library:
+                            type: string
+                          geoip_2_database:
+                            type: string
+                          geoip_database:
+                            type: string
+                          geoip_lookup_keys:
+                            type: string
+                          records:
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          skip_adding_null_record:
+                            type: boolean
+                        type: object
+                      grep:
+                        properties:
+                          and:
+                            items:
+                              properties:
+                                exclude:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                                regexp:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          exclude:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                pattern:
+                                  type: string
+                              required:
+                              - key
+                              - pattern
+                              type: object
+                            type: array
+                          or:
+                            items:
+                              properties:
+                                exclude:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                                regexp:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          regexp:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                pattern:
+                                  type: string
+                              required:
+                              - key
+                              - pattern
+                              type: object
+                            type: array
+                        type: object
+                      parser:
+                        properties:
+                          emit_invalid_record_to_error:
+                            type: boolean
+                          hash_value_field:
+                            type: string
+                          inject_key_prefix:
+                            type: string
+                          key_name:
+                            type: string
+                          parse:
+                            properties:
+                              delimiter:
+                                type: string
+                              delimiter_pattern:
+                                type: string
+                              estimate_current_event:
+                                type: boolean
+                              expression:
+                                type: string
+                              format:
+                                type: string
+                              format_firstline:
+                                type: string
+                              keep_time_key:
+                                type: boolean
+                              label_delimiter:
+                                type: string
+                              local_time:
+                                type: boolean
+                              multiline:
+                                items:
+                                  type: string
+                                type: array
+                              null_empty_string:
+                                type: boolean
+                              null_value_pattern:
+                                type: string
+                              patterns:
+                                items:
+                                  properties:
+                                    estimate_current_event:
+                                      type: boolean
+                                    expression:
+                                      type: string
+                                    format:
+                                      type: string
+                                    keep_time_key:
+                                      type: boolean
+                                    local_time:
+                                      type: boolean
+                                    null_empty_string:
+                                      type: boolean
+                                    null_value_pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    time_type:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                    type:
+                                      type: string
+                                    types:
+                                      type: string
+                                    utc:
+                                      type: boolean
+                                  type: object
+                                type: array
+                              time_format:
+                                type: string
+                              time_key:
+                                type: string
+                              time_type:
+                                type: string
+                              timezone:
+                                type: string
+                              type:
+                                type: string
+                              types:
+                                type: string
+                              utc:
+                                type: boolean
+                            type: object
+                          parsers:
+                            items:
+                              properties:
+                                delimiter:
+                                  type: string
+                                delimiter_pattern:
+                                  type: string
+                                estimate_current_event:
+                                  type: boolean
+                                expression:
+                                  type: string
+                                format:
+                                  type: string
+                                format_firstline:
+                                  type: string
+                                keep_time_key:
+                                  type: boolean
+                                label_delimiter:
+                                  type: string
+                                local_time:
+                                  type: boolean
+                                multiline:
+                                  items:
+                                    type: string
+                                  type: array
+                                null_empty_string:
+                                  type: boolean
+                                null_value_pattern:
+                                  type: string
+                                patterns:
+                                  items:
+                                    properties:
+                                      estimate_current_event:
+                                        type: boolean
+                                      expression:
+                                        type: string
+                                      format:
+                                        type: string
+                                      keep_time_key:
+                                        type: boolean
+                                      local_time:
+                                        type: boolean
+                                      null_empty_string:
+                                        type: boolean
+                                      null_value_pattern:
+                                        type: string
+                                      time_format:
+                                        type: string
+                                      time_key:
+                                        type: string
+                                      time_type:
+                                        type: string
+                                      timezone:
+                                        type: string
+                                      type:
+                                        type: string
+                                      types:
+                                        type: string
+                                      utc:
+                                        type: boolean
+                                    type: object
+                                  type: array
+                                time_format:
+                                  type: string
+                                time_key:
+                                  type: string
+                                time_type:
+                                  type: string
+                                timezone:
+                                  type: string
+                                type:
+                                  type: string
+                                types:
+                                  type: string
+                                utc:
+                                  type: boolean
+                              type: object
+                            type: array
+                          remove_key_name_field:
+                            type: boolean
+                          replace_invalid_sequence:
+                            type: boolean
+                          reserve_data:
+                            type: boolean
+                          reserve_time:
+                            type: boolean
+                        type: object
+                      prometheus:
+                        properties:
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          metrics:
+                            items:
+                              properties:
+                                buckets:
+                                  type: string
+                                desc:
+                                  type: string
+                                key:
+                                  type: string
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - desc
+                              - name
+                              - type
+                              type: object
+                            type: array
+                        type: object
+                      record_modifier:
+                        properties:
+                          char_encoding:
+                            type: string
+                          prepare_value:
+                            type: string
+                          records:
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          remove_keys:
+                            type: string
+                          replaces:
+                            items:
+                              properties:
+                                expression:
+                                  type: string
+                                key:
+                                  type: string
+                                replace:
+                                  type: string
+                              required:
+                              - expression
+                              - key
+                              - replace
+                              type: object
+                            type: array
+                          whitelist_keys:
+                            type: string
+                        type: object
+                      record_transformer:
+                        properties:
+                          auto_typecast:
+                            type: boolean
+                          enable_ruby:
+                            type: boolean
+                          keep_keys:
+                            type: string
+                          records:
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          remove_keys:
+                            type: string
+                          renew_record:
+                            type: boolean
+                          renew_time_key:
+                            type: string
+                        type: object
+                      stdout:
+                        properties:
+                          output_type:
+                            type: string
+                        type: object
+                      tag_normaliser:
+                        properties:
+                          format:
+                            type: string
+                        type: object
+                      throttle:
+                        properties:
+                          group_bucket_limit:
+                            type: integer
+                          group_bucket_period_s:
+                            type: integer
+                          group_drop_logs:
+                            type: boolean
+                          group_key:
+                            type: string
+                          group_reset_rate_s:
+                            type: integer
+                          group_warning_delay_s:
+                            type: integer
+                        type: object
+                    type: object
+                  type: array
+                globalOutputRefs:
+                  items:
+                    type: string
+                  type: array
+                outputRefs:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            enableRecreateWorkloadOnImmutableFieldChange:
+              type: boolean
+            flowConfigCheckDisabled:
+              type: boolean
+            flowConfigOverride:
+              type: string
+            fluentbit:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                bufferStorage:
+                  properties:
+                    storage.backlog.mem_limit:
+                      type: string
+                    storage.checksum:
+                      type: string
+                    storage.path:
+                      type: string
+                    storage.sync:
+                      type: string
+                  type: object
+                bufferStorageVolume:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                customConfigSecret:
+                  type: string
+                extraVolumeMounts:
+                  items:
+                    properties:
+                      destination:
+                        pattern: ^/.+$
+                        type: string
+                      readOnly:
+                        type: boolean
+                      source:
+                        pattern: ^/.+$
+                        type: string
+                    required:
+                    - destination
+                    - source
+                    type: object
+                  type: array
+                filterAws:
+                  properties:
+                    Match:
+                      type: string
+                    imds_version:
+                      type: string
+                  type: object
+                filterKubernetes:
+                  properties:
+                    Annotations:
+                      type: string
+                    Buffer_Size:
+                      type: string
+                    Dummy_Meta:
+                      type: string
+                    K8S-Logging.Exclude:
+                      type: string
+                    K8S-Logging.Parser:
+                      type: string
+                    Keep_Log:
+                      type: string
+                    Kube_CA_File:
+                      type: string
+                    Kube_CA_Path:
+                      type: string
+                    Kube_Tag_Prefix:
+                      type: string
+                    Kube_Token_File:
+                      type: string
+                    Kube_URL:
+                      type: string
+                    Kube_meta_preload_cache_dir:
+                      type: string
+                    Labels:
+                      type: string
+                    Match:
+                      type: string
+                    Merge_Log:
+                      type: string
+                    Merge_Log_Key:
+                      type: string
+                    Merge_Log_Trim:
+                      type: string
+                    Merge_Parser:
+                      type: string
+                    Regex_Parser:
+                      type: string
+                    Use_Journal:
+                      type: string
+                    tls.debug:
+                      type: string
+                    tls.verify:
+                      type: string
+                  type: object
+                image:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                inputTail:
+                  properties:
+                    Buffer_Chunk_Size:
+                      type: string
+                    Buffer_Max_Size:
+                      type: string
+                    DB:
+                      type: string
+                    DB_Sync:
+                      type: string
+                    Docker_Mode:
+                      type: string
+                    Docker_Mode_Flush:
+                      type: string
+                    Exclude_Path:
+                      type: string
+                    Ignore_Older:
+                      type: string
+                    Key:
+                      type: string
+                    Mem_Buf_Limit:
+                      type: string
+                    Multiline:
+                      type: string
+                    Multiline_Flush:
+                      type: string
+                    Parser:
+                      type: string
+                    Parser_Firstline:
+                      type: string
+                    Parser_N:
+                      items:
+                        type: string
+                      type: array
+                    Path:
+                      type: string
+                    Path_Key:
+                      type: string
+                    Refresh_Interval:
+                      type: string
+                    Rotate_Wait:
+                      type: string
+                    Skip_Long_Lines:
+                      type: string
+                    Tag:
+                      type: string
+                    Tag_Regex:
+                      type: string
+                    storage.type:
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                livenessDefaultCheck:
+                  type: boolean
+                livenessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                metrics:
+                  properties:
+                    interval:
+                      type: string
+                    path:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                    prometheusAnnotations:
+                      type: boolean
+                    serviceMonitor:
+                      type: boolean
+                    serviceMonitorConfig:
+                      properties:
+                        additionalLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        honorLabels:
+                          type: boolean
+                        metricRelabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                        relabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    timeout:
+                      type: string
+                  type: object
+                mountPath:
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                parser:
+                  type: string
+                podPriorityClassName:
+                  type: string
+                position_db:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                positiondb:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                readinessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                security:
+                  properties:
+                    podSecurityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    podSecurityPolicyCreate:
+                      type: boolean
+                    roleBasedAccessControlCreate:
+                      type: boolean
+                    securityContext:
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          properties:
+                            add:
+                              items:
+                                type: string
+                              type: array
+                            drop:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                  type: object
+                targetHost:
+                  type: string
+                targetPort:
+                  format: int32
+                  type: integer
+                tls:
+                  properties:
+                    enabled:
+                      type: boolean
+                    secretName:
+                      type: string
+                    sharedKey:
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            fluentd:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                bufferStorageVolume:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                configCheckAnnotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                configReloaderImage:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                disablePvc:
+                  type: boolean
+                fluentLogDestination:
+                  type: string
+                fluentOutLogrotate:
+                  properties:
+                    age:
+                      type: string
+                    enabled:
+                      type: boolean
+                    path:
+                      type: string
+                    size:
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                fluentdPvcSpec:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                image:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                livenessDefaultCheck:
+                  type: boolean
+                livenessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                logLevel:
+                  type: string
+                metrics:
+                  properties:
+                    interval:
+                      type: string
+                    path:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                    prometheusAnnotations:
+                      type: boolean
+                    serviceMonitor:
+                      type: boolean
+                    serviceMonitorConfig:
+                      properties:
+                        additionalLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        honorLabels:
+                          type: boolean
+                        metricRelabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                        relabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    timeout:
+                      type: string
+                  type: object
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                podPriorityClassName:
+                  type: string
+                port:
+                  format: int32
+                  type: integer
+                readinessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                scaling:
+                  properties:
+                    podManagementPolicy:
+                      type: string
+                    replicas:
+                      type: integer
+                  type: object
+                security:
+                  properties:
+                    podSecurityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    podSecurityPolicyCreate:
+                      type: boolean
+                    roleBasedAccessControlCreate:
+                      type: boolean
+                    securityContext:
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          properties:
+                            add:
+                              items:
+                                type: string
+                              type: array
+                            drop:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                  type: object
+                tls:
+                  properties:
+                    enabled:
+                      type: boolean
+                    secretName:
+                      type: string
+                    sharedKey:
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                volumeModImage:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                volumeMountChmod:
+                  type: boolean
+                workers:
+                  format: int32
+                  type: integer
+              type: object
+            loggingRef:
+              type: string
+            watchNamespaces:
+              items:
+                type: string
+              type: array
+          required:
+          - controlNamespace
+          type: object
+        status:
+          properties:
+            configCheckResults:
+              additionalProperties:
+                type: boolean
+              type: object
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/templates/_helpers.tpl
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "logging-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "logging-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Provides the namespace the chart will be installed in using the builtin .Release.Namespace,
+or, if provided, a manually overwritten namespace value.
+*/}}
+{{- define "logging-operator.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{ .Values.namespaceOverride -}}
+{{- else -}}
+{{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "logging-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "logging-operator.labels" -}}
+app.kubernetes.io/name: {{ include "logging-operator.name" . }}
+helm.sh/chart: {{ include "logging-operator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/templates/crds.yaml
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.createCustomResource -}}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/pkg/helm/testdata/crds-and-templates/logging-operator/values.yaml
+++ b/pkg/helm/testdata/crds-and-templates/logging-operator/values.yaml
@@ -1,0 +1,79 @@
+# Default values for logging-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/banzaicloud/logging-operator
+  tag: 3.7.1
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+annotations: {}
+
+## Deploy CRDs used by Logging Operator.
+##
+createCustomResource: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+http:
+  # http listen port number
+  port: 8080
+  # Service definition for query http service
+  service:
+    type: ClusterIP
+    clusterIP: None
+    # Annotations to query http service
+    annotations: {}
+    # Labels to query http service
+    labels: {}
+
+rbac:
+  enabled: true
+  psp:
+    enabled: false
+
+## SecurityContext holds pod-level security attributes and common container settings.
+## This defaults to non root user with uid 1000 and gid 2000.	*v1.PodSecurityContext	false
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+podSecurityContext: {}
+#  runAsNonRoot: true
+#  runAsUser: 1000
+#  fsGroup: 2000
+securityContext: {}
+#  allowPrivilegeEscalation: false
+#  readOnlyRootFilesystem: true
+  # capabilities:
+  #   drop: ["ALL"]
+
+## Operator priorityClassName
+##
+priorityClassName: {}
+
+monitoring:
+  # Create a Prometheus Operator ServiceMonitor object
+  serviceMonitor:
+    enabled: false

--- a/pkg/helm/testdata/crds-only/logging-operator/.helmignore
+++ b/pkg/helm/testdata/crds-only/logging-operator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/helm/testdata/crds-only/logging-operator/Chart.yaml
+++ b/pkg/helm/testdata/crds-only/logging-operator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "3.7.1"
+description: A Helm chart to install Banzai Cloud logging-operator
+name: logging-operator
+version: 3.7.1

--- a/pkg/helm/testdata/crds-only/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/pkg/helm/testdata/crds-only/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1,0 +1,2539 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: loggings.logging.banzaicloud.io
+spec:
+  group: logging.banzaicloud.io
+  names:
+    categories:
+    - logging-all
+    kind: Logging
+    listKind: LoggingList
+    plural: loggings
+    singular: logging
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allowClusterResourcesFromAllNamespaces:
+              type: boolean
+            controlNamespace:
+              type: string
+            defaultFlow:
+              properties:
+                filters:
+                  items:
+                    properties:
+                      concat:
+                        properties:
+                          continuous_line_regexp:
+                            type: string
+                          flush_interval:
+                            type: integer
+                          keep_partial_key:
+                            type: boolean
+                          keep_partial_metadata:
+                            type: string
+                          key:
+                            type: string
+                          multiline_end_regexp:
+                            type: string
+                          multiline_start_regexp:
+                            type: string
+                          n_lines:
+                            type: integer
+                          partial_key:
+                            type: string
+                          partial_value:
+                            type: string
+                          separator:
+                            type: string
+                          stream_identity_key:
+                            type: string
+                          timeout_label:
+                            type: string
+                          use_first_timestamp:
+                            type: boolean
+                          use_partial_metadata:
+                            type: string
+                        type: object
+                      dedot:
+                        properties:
+                          de_dot_nested:
+                            type: boolean
+                          de_dot_separator:
+                            type: string
+                        type: object
+                      detectExceptions:
+                        properties:
+                          languages:
+                            items:
+                              type: string
+                            type: array
+                          max_bytes:
+                            type: integer
+                          max_lines:
+                            type: integer
+                          message:
+                            type: string
+                          multiline_flush_interval:
+                            type: string
+                          remove_tag_prefix:
+                            type: string
+                          stream:
+                            type: string
+                        type: object
+                      geoip:
+                        properties:
+                          backend_library:
+                            type: string
+                          geoip_2_database:
+                            type: string
+                          geoip_database:
+                            type: string
+                          geoip_lookup_keys:
+                            type: string
+                          records:
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          skip_adding_null_record:
+                            type: boolean
+                        type: object
+                      grep:
+                        properties:
+                          and:
+                            items:
+                              properties:
+                                exclude:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                                regexp:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          exclude:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                pattern:
+                                  type: string
+                              required:
+                              - key
+                              - pattern
+                              type: object
+                            type: array
+                          or:
+                            items:
+                              properties:
+                                exclude:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                                regexp:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                    required:
+                                    - key
+                                    - pattern
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          regexp:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                pattern:
+                                  type: string
+                              required:
+                              - key
+                              - pattern
+                              type: object
+                            type: array
+                        type: object
+                      parser:
+                        properties:
+                          emit_invalid_record_to_error:
+                            type: boolean
+                          hash_value_field:
+                            type: string
+                          inject_key_prefix:
+                            type: string
+                          key_name:
+                            type: string
+                          parse:
+                            properties:
+                              delimiter:
+                                type: string
+                              delimiter_pattern:
+                                type: string
+                              estimate_current_event:
+                                type: boolean
+                              expression:
+                                type: string
+                              format:
+                                type: string
+                              format_firstline:
+                                type: string
+                              keep_time_key:
+                                type: boolean
+                              label_delimiter:
+                                type: string
+                              local_time:
+                                type: boolean
+                              multiline:
+                                items:
+                                  type: string
+                                type: array
+                              null_empty_string:
+                                type: boolean
+                              null_value_pattern:
+                                type: string
+                              patterns:
+                                items:
+                                  properties:
+                                    estimate_current_event:
+                                      type: boolean
+                                    expression:
+                                      type: string
+                                    format:
+                                      type: string
+                                    keep_time_key:
+                                      type: boolean
+                                    local_time:
+                                      type: boolean
+                                    null_empty_string:
+                                      type: boolean
+                                    null_value_pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    time_type:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                    type:
+                                      type: string
+                                    types:
+                                      type: string
+                                    utc:
+                                      type: boolean
+                                  type: object
+                                type: array
+                              time_format:
+                                type: string
+                              time_key:
+                                type: string
+                              time_type:
+                                type: string
+                              timezone:
+                                type: string
+                              type:
+                                type: string
+                              types:
+                                type: string
+                              utc:
+                                type: boolean
+                            type: object
+                          parsers:
+                            items:
+                              properties:
+                                delimiter:
+                                  type: string
+                                delimiter_pattern:
+                                  type: string
+                                estimate_current_event:
+                                  type: boolean
+                                expression:
+                                  type: string
+                                format:
+                                  type: string
+                                format_firstline:
+                                  type: string
+                                keep_time_key:
+                                  type: boolean
+                                label_delimiter:
+                                  type: string
+                                local_time:
+                                  type: boolean
+                                multiline:
+                                  items:
+                                    type: string
+                                  type: array
+                                null_empty_string:
+                                  type: boolean
+                                null_value_pattern:
+                                  type: string
+                                patterns:
+                                  items:
+                                    properties:
+                                      estimate_current_event:
+                                        type: boolean
+                                      expression:
+                                        type: string
+                                      format:
+                                        type: string
+                                      keep_time_key:
+                                        type: boolean
+                                      local_time:
+                                        type: boolean
+                                      null_empty_string:
+                                        type: boolean
+                                      null_value_pattern:
+                                        type: string
+                                      time_format:
+                                        type: string
+                                      time_key:
+                                        type: string
+                                      time_type:
+                                        type: string
+                                      timezone:
+                                        type: string
+                                      type:
+                                        type: string
+                                      types:
+                                        type: string
+                                      utc:
+                                        type: boolean
+                                    type: object
+                                  type: array
+                                time_format:
+                                  type: string
+                                time_key:
+                                  type: string
+                                time_type:
+                                  type: string
+                                timezone:
+                                  type: string
+                                type:
+                                  type: string
+                                types:
+                                  type: string
+                                utc:
+                                  type: boolean
+                              type: object
+                            type: array
+                          remove_key_name_field:
+                            type: boolean
+                          replace_invalid_sequence:
+                            type: boolean
+                          reserve_data:
+                            type: boolean
+                          reserve_time:
+                            type: boolean
+                        type: object
+                      prometheus:
+                        properties:
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          metrics:
+                            items:
+                              properties:
+                                buckets:
+                                  type: string
+                                desc:
+                                  type: string
+                                key:
+                                  type: string
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - desc
+                              - name
+                              - type
+                              type: object
+                            type: array
+                        type: object
+                      record_modifier:
+                        properties:
+                          char_encoding:
+                            type: string
+                          prepare_value:
+                            type: string
+                          records:
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          remove_keys:
+                            type: string
+                          replaces:
+                            items:
+                              properties:
+                                expression:
+                                  type: string
+                                key:
+                                  type: string
+                                replace:
+                                  type: string
+                              required:
+                              - expression
+                              - key
+                              - replace
+                              type: object
+                            type: array
+                          whitelist_keys:
+                            type: string
+                        type: object
+                      record_transformer:
+                        properties:
+                          auto_typecast:
+                            type: boolean
+                          enable_ruby:
+                            type: boolean
+                          keep_keys:
+                            type: string
+                          records:
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          remove_keys:
+                            type: string
+                          renew_record:
+                            type: boolean
+                          renew_time_key:
+                            type: string
+                        type: object
+                      stdout:
+                        properties:
+                          output_type:
+                            type: string
+                        type: object
+                      tag_normaliser:
+                        properties:
+                          format:
+                            type: string
+                        type: object
+                      throttle:
+                        properties:
+                          group_bucket_limit:
+                            type: integer
+                          group_bucket_period_s:
+                            type: integer
+                          group_drop_logs:
+                            type: boolean
+                          group_key:
+                            type: string
+                          group_reset_rate_s:
+                            type: integer
+                          group_warning_delay_s:
+                            type: integer
+                        type: object
+                    type: object
+                  type: array
+                globalOutputRefs:
+                  items:
+                    type: string
+                  type: array
+                outputRefs:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            enableRecreateWorkloadOnImmutableFieldChange:
+              type: boolean
+            flowConfigCheckDisabled:
+              type: boolean
+            flowConfigOverride:
+              type: string
+            fluentbit:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                bufferStorage:
+                  properties:
+                    storage.backlog.mem_limit:
+                      type: string
+                    storage.checksum:
+                      type: string
+                    storage.path:
+                      type: string
+                    storage.sync:
+                      type: string
+                  type: object
+                bufferStorageVolume:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                customConfigSecret:
+                  type: string
+                extraVolumeMounts:
+                  items:
+                    properties:
+                      destination:
+                        pattern: ^/.+$
+                        type: string
+                      readOnly:
+                        type: boolean
+                      source:
+                        pattern: ^/.+$
+                        type: string
+                    required:
+                    - destination
+                    - source
+                    type: object
+                  type: array
+                filterAws:
+                  properties:
+                    Match:
+                      type: string
+                    imds_version:
+                      type: string
+                  type: object
+                filterKubernetes:
+                  properties:
+                    Annotations:
+                      type: string
+                    Buffer_Size:
+                      type: string
+                    Dummy_Meta:
+                      type: string
+                    K8S-Logging.Exclude:
+                      type: string
+                    K8S-Logging.Parser:
+                      type: string
+                    Keep_Log:
+                      type: string
+                    Kube_CA_File:
+                      type: string
+                    Kube_CA_Path:
+                      type: string
+                    Kube_Tag_Prefix:
+                      type: string
+                    Kube_Token_File:
+                      type: string
+                    Kube_URL:
+                      type: string
+                    Kube_meta_preload_cache_dir:
+                      type: string
+                    Labels:
+                      type: string
+                    Match:
+                      type: string
+                    Merge_Log:
+                      type: string
+                    Merge_Log_Key:
+                      type: string
+                    Merge_Log_Trim:
+                      type: string
+                    Merge_Parser:
+                      type: string
+                    Regex_Parser:
+                      type: string
+                    Use_Journal:
+                      type: string
+                    tls.debug:
+                      type: string
+                    tls.verify:
+                      type: string
+                  type: object
+                image:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                inputTail:
+                  properties:
+                    Buffer_Chunk_Size:
+                      type: string
+                    Buffer_Max_Size:
+                      type: string
+                    DB:
+                      type: string
+                    DB_Sync:
+                      type: string
+                    Docker_Mode:
+                      type: string
+                    Docker_Mode_Flush:
+                      type: string
+                    Exclude_Path:
+                      type: string
+                    Ignore_Older:
+                      type: string
+                    Key:
+                      type: string
+                    Mem_Buf_Limit:
+                      type: string
+                    Multiline:
+                      type: string
+                    Multiline_Flush:
+                      type: string
+                    Parser:
+                      type: string
+                    Parser_Firstline:
+                      type: string
+                    Parser_N:
+                      items:
+                        type: string
+                      type: array
+                    Path:
+                      type: string
+                    Path_Key:
+                      type: string
+                    Refresh_Interval:
+                      type: string
+                    Rotate_Wait:
+                      type: string
+                    Skip_Long_Lines:
+                      type: string
+                    Tag:
+                      type: string
+                    Tag_Regex:
+                      type: string
+                    storage.type:
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                livenessDefaultCheck:
+                  type: boolean
+                livenessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                metrics:
+                  properties:
+                    interval:
+                      type: string
+                    path:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                    prometheusAnnotations:
+                      type: boolean
+                    serviceMonitor:
+                      type: boolean
+                    serviceMonitorConfig:
+                      properties:
+                        additionalLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        honorLabels:
+                          type: boolean
+                        metricRelabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                        relabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    timeout:
+                      type: string
+                  type: object
+                mountPath:
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                parser:
+                  type: string
+                podPriorityClassName:
+                  type: string
+                position_db:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                positiondb:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                readinessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                security:
+                  properties:
+                    podSecurityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    podSecurityPolicyCreate:
+                      type: boolean
+                    roleBasedAccessControlCreate:
+                      type: boolean
+                    securityContext:
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          properties:
+                            add:
+                              items:
+                                type: string
+                              type: array
+                            drop:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                  type: object
+                targetHost:
+                  type: string
+                targetPort:
+                  format: int32
+                  type: integer
+                tls:
+                  properties:
+                    enabled:
+                      type: boolean
+                    secretName:
+                      type: string
+                    sharedKey:
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            fluentd:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                bufferStorageVolume:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                configCheckAnnotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                configReloaderImage:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                disablePvc:
+                  type: boolean
+                fluentLogDestination:
+                  type: string
+                fluentOutLogrotate:
+                  properties:
+                    age:
+                      type: string
+                    enabled:
+                      type: boolean
+                    path:
+                      type: string
+                    size:
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                fluentdPvcSpec:
+                  properties:
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                      type: object
+                    host_path:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    pvc:
+                      properties:
+                        source:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                image:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                livenessDefaultCheck:
+                  type: boolean
+                livenessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                logLevel:
+                  type: string
+                metrics:
+                  properties:
+                    interval:
+                      type: string
+                    path:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                    prometheusAnnotations:
+                      type: boolean
+                    serviceMonitor:
+                      type: boolean
+                    serviceMonitorConfig:
+                      properties:
+                        additionalLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        honorLabels:
+                          type: boolean
+                        metricRelabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                        relabelings:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              modulus:
+                                format: int64
+                                type: integer
+                              regex:
+                                type: string
+                              replacement:
+                                type: string
+                              separator:
+                                type: string
+                              sourceLabels:
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    timeout:
+                      type: string
+                  type: object
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                podPriorityClassName:
+                  type: string
+                port:
+                  format: int32
+                  type: integer
+                readinessProbe:
+                  properties:
+                    exec:
+                      properties:
+                        command:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      format: int32
+                      type: integer
+                    httpGet:
+                      properties:
+                        host:
+                          type: string
+                        httpHeaders:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    timeoutSeconds:
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                scaling:
+                  properties:
+                    podManagementPolicy:
+                      type: string
+                    replicas:
+                      type: integer
+                  type: object
+                security:
+                  properties:
+                    podSecurityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    podSecurityPolicyCreate:
+                      type: boolean
+                    roleBasedAccessControlCreate:
+                      type: boolean
+                    securityContext:
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          properties:
+                            add:
+                              items:
+                                type: string
+                              type: array
+                            drop:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                  type: object
+                tls:
+                  properties:
+                    enabled:
+                      type: boolean
+                    secretName:
+                      type: string
+                    sharedKey:
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                volumeModImage:
+                  properties:
+                    pullPolicy:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                  type: object
+                volumeMountChmod:
+                  type: boolean
+                workers:
+                  format: int32
+                  type: integer
+              type: object
+            loggingRef:
+              type: string
+            watchNamespaces:
+              items:
+                type: string
+              type: array
+          required:
+          - controlNamespace
+          type: object
+        status:
+          properties:
+            configCheckResults:
+              additionalProperties:
+                type: boolean
+              type: object
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/helm/testdata/crds-only/logging-operator/templates/_helpers.tpl
+++ b/pkg/helm/testdata/crds-only/logging-operator/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "logging-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "logging-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Provides the namespace the chart will be installed in using the builtin .Release.Namespace,
+or, if provided, a manually overwritten namespace value.
+*/}}
+{{- define "logging-operator.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{ .Values.namespaceOverride -}}
+{{- else -}}
+{{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "logging-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "logging-operator.labels" -}}
+app.kubernetes.io/name: {{ include "logging-operator.name" . }}
+helm.sh/chart: {{ include "logging-operator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/pkg/helm/testdata/crds-only/logging-operator/values.yaml
+++ b/pkg/helm/testdata/crds-only/logging-operator/values.yaml
@@ -1,0 +1,79 @@
+# Default values for logging-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/banzaicloud/logging-operator
+  tag: 3.7.1
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+annotations: {}
+
+## Deploy CRDs used by Logging Operator.
+##
+createCustomResource: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+http:
+  # http listen port number
+  port: 8080
+  # Service definition for query http service
+  service:
+    type: ClusterIP
+    clusterIP: None
+    # Annotations to query http service
+    annotations: {}
+    # Labels to query http service
+    labels: {}
+
+rbac:
+  enabled: true
+  psp:
+    enabled: false
+
+## SecurityContext holds pod-level security attributes and common container settings.
+## This defaults to non root user with uid 1000 and gid 2000.	*v1.PodSecurityContext	false
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+podSecurityContext: {}
+#  runAsNonRoot: true
+#  runAsUser: 1000
+#  fsGroup: 2000
+securityContext: {}
+#  allowPrivilegeEscalation: false
+#  readOnlyRootFilesystem: true
+  # capabilities:
+  #   drop: ["ALL"]
+
+## Operator priorityClassName
+##
+priorityClassName: {}
+
+monitoring:
+  # Create a Prometheus Operator ServiceMonitor object
+  serviceMonitor:
+    enabled: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Parses objects from crds directory as well, which is typical for helm v3 charts.

### Why?
Previously only those CRDs were parsed that were present in the template directory.
