### PR TITLE
Fix panic when terminal reports 0 width

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -180,8 +180,11 @@ func (log *logger) Info(msg string, vals ...interface{}) {
 
 		if log.truncate {
 			w, _ := terminal.Width()
-			w -= 3 // reduced by 3 (spinner char, space, leeway)
-			msg = log.truncateString(msg, int(w))
+			// vscode debug window returns 0 width (without an error)
+			if w > 3 {
+				w -= 3 // reduced by 3 (spinner char, space, leeway)
+				msg = log.truncateString(msg, int(w))
+			}
 		}
 
 		if log.spinner == nil {


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?

VSCode's debug window reports 0 width. This results in the following panic due to the truncateString's implementation:

```
   panic: runtime error: slice bounds out of range [:-3]
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
