### PR TITLE
Helm template modifiers and overlays

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.2.1
+	github.com/go-test/deep v1.0.7
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/json-iterator/go v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
+github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gobuffalo/envy v1.7.1/go.mod h1:FurDp9+EDPE4aIUS3ZLyD+7/9fpx7YRt/ukY6jIHf0w=
 github.com/gobuffalo/logger v1.0.1/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8ze5s8JvPs=

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -254,6 +254,9 @@ func (rec *NativeReconciler) Reconcile(owner runtime.Object) (*reconcile.Result,
 		o, state, err := r()
 		if err != nil {
 			combinedResult.CombineErr(err)
+		} else if o == nil || state == nil {
+			rec.Log.Info("skipping resource builder reconciliation due to object or desired state was nil")
+			continue
 		} else {
 			var objectMeta metav1.Object
 			objectMeta, err = rec.addComponentIDAnnotation(o, componentID)

--- a/pkg/resources/overlay.go
+++ b/pkg/resources/overlay.go
@@ -45,7 +45,7 @@ type OverlayPatchType string
 
 const (
 	ReplaceOverlayPatchType OverlayPatchType = "replace"
-	DeleteOverlayPatchType  OverlayPatchType = "delete"
+	DeleteOverlayPatchType  OverlayPatchType = "remove"
 )
 
 // +kubebuilder:object:generate=true

--- a/pkg/resources/overlay_test.go
+++ b/pkg/resources/overlay_test.go
@@ -1,0 +1,113 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/banzaicloud/operator-tools/pkg/types"
+	"github.com/banzaicloud/operator-tools/pkg/utils"
+	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestPatchYAMLModifier(t *testing.T) {
+	objectName := "test-object"
+	testNamespace := "test-ns"
+	parser := NewObjectParser(clientgoscheme.Scheme)
+	tests := map[string]struct {
+		overlay           K8SResourceOverlay
+		object            runtime.Object
+		want              runtime.Object
+		assertErr         func(error)
+		assertModifierErr func(error)
+	}{
+		"matching patching": {
+			overlay: K8SResourceOverlay{
+				ObjectKey: types.ObjectKey{
+					Name:      objectName,
+					Namespace: testNamespace,
+				},
+				Patches: []K8SResourceOverlayPatch{
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/loadBalancerIP"),
+						Value: utils.StringPointer("5.6.7.8"),
+					},
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/ports/0/name"),
+						Value: utils.StringPointer("port2"),
+					},
+					{
+						Type:  DeleteOverlayPatchType,
+						Path:  utils.StringPointer("/spec/ports/1"),
+					},
+				},
+			},
+			object: &v1.Service{
+				TypeMeta: v12.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: v12.ObjectMeta{
+					Name:      objectName,
+					Namespace: testNamespace,
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerIP: "1.2.3.4",
+					Ports: []v1.ServicePort{
+						{
+							Port: 123,
+							Name: "port1",
+						},
+						{
+							Port: 456,
+							Name: "port-to-delete",
+						},
+					},
+				},
+			},
+			want: &v1.Service{
+				TypeMeta: v12.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: v12.ObjectMeta{
+					Name:      objectName,
+					Namespace: testNamespace,
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerIP: "5.6.7.8",
+					Ports: []v1.ServicePort{
+						{
+							Port: 123,
+							Name: "port2",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := PatchYAMLModifier(tt.overlay, parser)
+			if tt.assertErr != nil {
+				tt.assertErr(err)
+			} else {
+				assert.NoError(t, err)
+			}
+			patched, err := got(tt.object)
+			if tt.assertModifierErr != nil {
+				tt.assertModifierErr(err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if diff := deep.Equal(patched, tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/resources/overlay_test.go
+++ b/pkg/resources/overlay_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Adds the ability to use custom modifiers and yaml layers for resources prepared by the helm template reconciler before applying them on the cluster.

Modifiers can be used to apply arbitrary transformations on `runtime.Object`s from client code, while yaml layers can also perform deletions and have the ability to be embedded into CRDs directly.