### PR TITLE
Configurable recreate strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/banzaicloud/operator-tools
 
-go 1.13
+go 1.15
 
 require (
 	emperror.dev/errors v0.8.0

--- a/pkg/reconciler/resource_test.go
+++ b/pkg/reconciler/resource_test.go
@@ -21,9 +21,12 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestNewReconcilerWith(t *testing.T) {
@@ -85,3 +88,94 @@ func TestNewReconcilerWithUnstructured(t *testing.T) {
 	assert.Equal(t, created.Name, "test")
 	assert.Equal(t, created.Namespace, controlNamespace)
 }
+
+func TestRecreateObjectFailIfNotAllowed(t *testing.T) {
+	testData := []struct {
+		name string
+		desired runtime.Object
+		reconciler reconciler.ResourceReconciler
+		update func(object runtime.Object) runtime.Object
+		wantError func(error)
+		wantResult func(result *reconcile.Result)
+	}{
+		{
+			name: "fails to recreate service",
+			desired: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: testNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.100",
+					Ports: []corev1.ServicePort{
+						{
+							Port: 123,
+						},
+					},
+				},
+			},
+			reconciler: reconciler.NewReconcilerWith(k8sClient,
+				reconciler.WithEnableRecreateWorkload(),
+				reconciler.WithRecreateEnabledForNothing(),
+			),
+			update: func(object runtime.Object) runtime.Object {
+				object.(*corev1.Service).Spec.ClusterIP = "10.0.0.102"
+				return object
+			},
+			wantError: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "immutable")
+			},
+		},
+		{
+			name: "allowed to recreate service by default",
+			desired: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: testNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.100",
+					Ports: []corev1.ServicePort{
+						{
+							Port: 123,
+						},
+					},
+				},
+			},
+			reconciler: reconciler.NewReconcilerWith(k8sClient,
+				reconciler.WithEnableRecreateWorkload(),
+				//reconciler.WithRecreateEnabledForNothing(),
+			),
+			update: func(object runtime.Object) runtime.Object {
+				object.(*corev1.Service).Spec.ClusterIP = "10.0.0.102"
+				return object
+			},
+			wantResult: func(result *reconcile.Result) {
+				require.NotNil(t, result)
+				require.True(t, result.Requeue)
+			},
+		},
+	}
+
+	for _, tt := range testData {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.reconciler.ReconcileResource(tt.desired, reconciler.StatePresent)
+			require.NoError(t, err)
+
+			result, err := tt.reconciler.ReconcileResource(tt.update(tt.desired), reconciler.StatePresent)
+			if tt.wantError != nil {
+				tt.wantError(err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantResult != nil {
+				tt.wantResult(result)
+			} else {
+				require.Nil(t, result)
+			}
+		})
+	}
+}
+

--- a/pkg/reconciler/resource_test.go
+++ b/pkg/reconciler/resource_test.go
@@ -146,7 +146,6 @@ func TestRecreateObjectFailIfNotAllowed(t *testing.T) {
 			},
 			reconciler: reconciler.NewReconcilerWith(k8sClient,
 				reconciler.WithEnableRecreateWorkload(),
-				//reconciler.WithRecreateEnabledForNothing(),
 			),
 			update: func(object runtime.Object) runtime.Object {
 				object.(*corev1.Service).Spec.ClusterIP = "10.0.0.21"

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -60,6 +60,14 @@ func PointerToInt(i *int) int {
 	return *i
 }
 
+func PointerToInt32(i *int32) int32 {
+	if i == nil {
+		return 0
+	}
+
+	return *i
+}
+
 func PointerToString(s *string) string {
 	if s == nil {
 		return ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Fixes | #51 #48 
| License         | Apache 2.0


### What's in this PR?
Makes the recreate strategy configurable in terms of:
- allow to configure the set of resource types to be recreated (service, daemonset, statefulset, deployment by default)
- allow to configure the backoff delay (10 sec by default)
- allow to configure immediate recreation of resources with background deletion (foreground is kept by default)
- check the error message to contain the "immutable" keyword by default (can be disabled)

### Why?
Right now the strategy is hardcoded as:
- delete *any* resources using the foreground deletion policy for *any* 422 update errors
- wait 10 seconds before creating the resource again
