### PR TITLE
fix object key matching in overlay patching

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -20,6 +20,10 @@ ignored = [
   "github.com/uber-go/tally", # MIT
   "github.com/russross/blackfriday", # BSD
 
+  "github.com/xeipuuv/gojsonpointer", # Apache2
+  "github.com/xeipuuv/gojsonreference", # Apache2
+  "github.com/xeipuuv/gojsonschema", # Apache2
+
   "github.com/davecgh/go-spew", # ISC license
   "github.com/oracle/oci-go-sdk", # UPL-1.0
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -322,6 +322,12 @@ func (log *logger) stopSpinner() {
 }
 
 func (log *logger) copyLogger() logger {
+	names := make([]string, len(log.names))
+	copy(names, log.names)
+
+	values := make([]interface{}, len(log.values))
+	copy(values, log.values)
+
 	return logger{
 		level:              log.level,
 		names:              log.names,

--- a/pkg/resources/overlay.go
+++ b/pkg/resources/overlay.go
@@ -106,7 +106,7 @@ func PatchYAMLModifier(overlay K8SResourceOverlay, parser *ObjectParser) (Object
 			return o, nil
 		}
 
-		if meta.GetName() != overlay.ObjectKey.Name || meta.GetNamespace() != overlay.ObjectKey.Namespace {
+		if (overlay.ObjectKey.Name != "" && meta.GetName() != overlay.ObjectKey.Name) || (overlay.ObjectKey.Namespace != "" && meta.GetNamespace() != overlay.ObjectKey.Namespace) {
 			return o, nil
 		}
 

--- a/pkg/resources/overlay_test.go
+++ b/pkg/resources/overlay_test.go
@@ -17,19 +17,65 @@ package resources
 import (
 	"testing"
 
-	"github.com/banzaicloud/operator-tools/pkg/types"
-	"github.com/banzaicloud/operator-tools/pkg/utils"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/banzaicloud/operator-tools/pkg/types"
+	"github.com/banzaicloud/operator-tools/pkg/utils"
 )
 
 func TestPatchYAMLModifier(t *testing.T) {
 	objectName := "test-object"
 	testNamespace := "test-ns"
+
+	baseObject := &v1.Service{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:      objectName,
+			Namespace: testNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			LoadBalancerIP: "1.2.3.4",
+			Ports: []v1.ServicePort{
+				{
+					Port: 123,
+					Name: "port1",
+				},
+				{
+					Port: 456,
+					Name: "port-to-delete",
+				},
+			},
+		},
+	}
+
+	baseWantObject := &v1.Service{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:      objectName,
+			Namespace: testNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			LoadBalancerIP: "5.6.7.8",
+			Ports: []v1.ServicePort{
+				{
+					Port: 123,
+					Name: "port2",
+				},
+			},
+		},
+	}
+
 	parser := NewObjectParser(clientgoscheme.Scheme)
 	tests := map[string]struct {
 		overlay           K8SResourceOverlay
@@ -56,53 +102,85 @@ func TestPatchYAMLModifier(t *testing.T) {
 						Value: utils.StringPointer("port2"),
 					},
 					{
-						Type:  DeleteOverlayPatchType,
-						Path:  utils.StringPointer("/spec/ports/1"),
+						Type: DeleteOverlayPatchType,
+						Path: utils.StringPointer("/spec/ports/1"),
 					},
 				},
 			},
-			object: &v1.Service{
-				TypeMeta: v12.TypeMeta{
-					Kind:       "Service",
-					APIVersion: "v1",
+			object: baseObject,
+			want:   baseWantObject,
+		},
+		"matching wo objectkey patching": {
+			overlay: K8SResourceOverlay{
+				Patches: []K8SResourceOverlayPatch{
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/loadBalancerIP"),
+						Value: utils.StringPointer("5.6.7.8"),
+					},
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/ports/0/name"),
+						Value: utils.StringPointer("port2"),
+					},
+					{
+						Type: DeleteOverlayPatchType,
+						Path: utils.StringPointer("/spec/ports/1"),
+					},
 				},
-				ObjectMeta: v12.ObjectMeta{
-					Name:      objectName,
+			},
+			object: baseObject,
+			want:   baseWantObject,
+		},
+		"matching wo objectkey namespace patching": {
+			overlay: K8SResourceOverlay{
+				ObjectKey: types.ObjectKey{
+					Name: objectName,
+				},
+				Patches: []K8SResourceOverlayPatch{
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/loadBalancerIP"),
+						Value: utils.StringPointer("5.6.7.8"),
+					},
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/ports/0/name"),
+						Value: utils.StringPointer("port2"),
+					},
+					{
+						Type: DeleteOverlayPatchType,
+						Path: utils.StringPointer("/spec/ports/1"),
+					},
+				},
+			},
+			object: baseObject,
+			want:   baseWantObject,
+		},
+		"matching wo objectkey name patching": {
+			overlay: K8SResourceOverlay{
+				ObjectKey: types.ObjectKey{
 					Namespace: testNamespace,
 				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "1.2.3.4",
-					Ports: []v1.ServicePort{
-						{
-							Port: 123,
-							Name: "port1",
-						},
-						{
-							Port: 456,
-							Name: "port-to-delete",
-						},
+				Patches: []K8SResourceOverlayPatch{
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/loadBalancerIP"),
+						Value: utils.StringPointer("5.6.7.8"),
+					},
+					{
+						Type:  ReplaceOverlayPatchType,
+						Path:  utils.StringPointer("/spec/ports/0/name"),
+						Value: utils.StringPointer("port2"),
+					},
+					{
+						Type: DeleteOverlayPatchType,
+						Path: utils.StringPointer("/spec/ports/1"),
 					},
 				},
 			},
-			want: &v1.Service{
-				TypeMeta: v12.TypeMeta{
-					Kind:       "Service",
-					APIVersion: "v1",
-				},
-				ObjectMeta: v12.ObjectMeta{
-					Name:      objectName,
-					Namespace: testNamespace,
-				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "5.6.7.8",
-					Ports: []v1.ServicePort{
-						{
-							Port: 123,
-							Name: "port2",
-						},
-					},
-				},
-			},
+			object: baseObject,
+			want:   baseWantObject,
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Makes object name and/or namespace checking optional while matching objects in overlay patching.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Object key matching in overlay patching should be optional.
