### PR TITLE
Adapt to controller-runtime new Reconciler interface, extend CRD v1 support, fix spinner

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -310,6 +310,7 @@ func (log *logger) initSpinner() {
 	defer log.mux.Unlock()
 	log.spinner = spinner.New(spinner.CharSets[21], 100*time.Millisecond, spinner.WithHiddenCursor(false), spinner.WithWriter(log.out))
 	_ = log.spinner.Color("green")
+	log.spinner.Start()
 }
 
 func (log *logger) stopSpinner() {

--- a/pkg/reconciler/component.go
+++ b/pkg/reconciler/component.go
@@ -15,6 +15,8 @@
 package reconciler
 
 import (
+	"context"
+
 	"emperror.dev/errors"
 	"github.com/banzaicloud/operator-tools/pkg/types"
 	"github.com/go-logr/logr"
@@ -58,7 +60,7 @@ type Dispatcher struct {
 }
 
 // Reconcile implements reconcile.Reconciler in a generic way from the controller-runtime library
-func (r *Dispatcher) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+func (r *Dispatcher) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	object, err := r.ResourceGetter(req)
 	if err != nil {
 		return reconcile.Result{}, errors.WithStack(err)

--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -23,8 +23,8 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/wait"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	crdv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -281,9 +281,9 @@ LOOP:
 			if rec.setControllerRef {
 				skipControllerRef := false
 				switch o.(type) {
-				case *v1beta1.CustomResourceDefinition:
+				case *crdv1.CustomResourceDefinition:
 					skipControllerRef = true
-				case *v1.CustomResourceDefinition:
+				case *crdv1beta1.CustomResourceDefinition:
 					skipControllerRef = true
 				case *corev1.Namespace:
 					skipControllerRef = true

--- a/pkg/resources/objectmodifiers.go
+++ b/pkg/resources/objectmodifiers.go
@@ -19,6 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -69,6 +70,10 @@ func WorkloadImagePullSecretsModifier(imagePullSecrets ...[]corev1.LocalObjectRe
 func ClearCRDStatusModifier(o runtime.Object) (runtime.Object, error) {
 	if crd, ok := o.(*apiextensionsv1beta1.CustomResourceDefinition); ok {
 		crd.Status = apiextensionsv1beta1.CustomResourceDefinitionStatus{}
+	}
+
+	if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
+		crd.Status = apiextensionsv1.CustomResourceDefinitionStatus{}
 	}
 
 	return o, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Dispatcher is adapted to the new controller-runtime interface
Spinner issue fixed, where the `Color` method now doesn't invoke `Restart`, which we built upon see https://github.com/briandowns/spinner/commit/7cc7ee998e515840dfff3c5e2abb38380f184129
Extend CRD v1 support where it was missing

