### PR TITLE
introduce a new annotation to specify create-only desired state

### DIFF
--- a/pkg/reconciler/native.go
+++ b/pkg/reconciler/native.go
@@ -312,7 +312,7 @@ LOOP:
 			}
 
 			// desired state can be overriden to create-only by an annotation
-			if _, ok := objectMeta.GetAnnotations()[types.BanzaiCloudCreateOnlyDesiredState]; ok {
+			if _, ok := objectMeta.GetAnnotations()[types.BanzaiCloudDesiredStateCreated]; ok {
 				if ds, ok := state.(DynamicDesiredState); ok && ds.DesiredState == StatePresent || state == StatePresent {
 					state = StateCreated
 				}

--- a/pkg/reconciler/native_test.go
+++ b/pkg/reconciler/native_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -312,11 +311,11 @@ func TestNativeReconcilerFailToSetCrossNamespaceControllerRef(t *testing.T) {
 
 func TestCreatedDesiredStateAnnotationWithStaticStatePresent(t *testing.T) {
 	desired := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "test-desired-state-with-static-present",
 			Namespace: controlNamespace,
 			Annotations: map[string]string{
-				ottypes.BanzaiCloudCreateOnlyDesiredState: "true",
+				ottypes.BanzaiCloudDesiredStateCreated: "true",
 			},
 		},
 		Data: map[string]string{
@@ -365,11 +364,11 @@ func TestCreatedDesiredStateAnnotationWithStaticStatePresent(t *testing.T) {
 
 func TestCreatedDesiredStateAnnotationWithDynamicStatePresent(t *testing.T) {
 	desired := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "test-desired-state-with-dynamic-present",
 			Namespace: controlNamespace,
 			Annotations: map[string]string{
-				ottypes.BanzaiCloudCreateOnlyDesiredState: "true",
+				ottypes.BanzaiCloudDesiredStateCreated: "true",
 			},
 		},
 		Data: map[string]string{

--- a/pkg/reconciler/native_test.go
+++ b/pkg/reconciler/native_test.go
@@ -15,20 +15,26 @@
 package reconciler_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
+	ottypes "github.com/banzaicloud/operator-tools/pkg/types"
+	"github.com/banzaicloud/operator-tools/pkg/utils"
 )
 
 // FakeResourceOwner object implements the ResourceOwner interface by piggybacking a ConfigMap (oink-oink)
@@ -302,6 +308,114 @@ func TestNativeReconcilerFailToSetCrossNamespaceControllerRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error: %s", err.Error())
 	}
+}
+
+func TestCreatedDesiredStateAnnotationWithStaticStatePresent(t *testing.T) {
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-desired-state-with-static-present",
+			Namespace: controlNamespace,
+			Annotations: map[string]string{
+				ottypes.BanzaiCloudCreateOnlyDesiredState: "true",
+			},
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+
+	r := reconciler.NewReconcilerWith(k8sClient)
+	result, err := r.ReconcileResource(desired, reconciler.StatePresent)
+	if result != nil {
+		t.Fatalf("result expected to be nil if everything went smooth")
+	}
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	desiredMutated := desired.DeepCopy()
+	desiredMutated.Data["a"] = "c"
+
+	nr := reconciler.NewNativeReconcilerWithDefaults("test", k8sClient, clientgoscheme.Scheme, logr.DiscardLogger{}, func(parent reconciler.ResourceOwner, object interface{}) []reconciler.ResourceBuilder {
+		return []reconciler.ResourceBuilder{
+			func() (runtime.Object, reconciler.DesiredState, error) {
+				return desiredMutated, reconciler.StatePresent, nil
+			},
+		}
+	}, func() []schema.GroupVersionKind {
+		return nil
+	}, func(_ runtime.Object) (reconciler.ResourceOwner, interface{}) {
+		return nil, nil
+	})
+
+	_, err = nr.Reconcile(desired)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	created := &corev1.ConfigMap{}
+	if err := k8sClient.Get(context.TODO(), utils.ObjectKeyFromObjectMeta(desired), created); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	assert.Equal(t, created.Name, desired.Name)
+	assert.Equal(t, created.Namespace, desired.Namespace)
+	assert.Equal(t, created.Data["a"], desired.Data["a"])
+}
+
+func TestCreatedDesiredStateAnnotationWithDynamicStatePresent(t *testing.T) {
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-desired-state-with-dynamic-present",
+			Namespace: controlNamespace,
+			Annotations: map[string]string{
+				ottypes.BanzaiCloudCreateOnlyDesiredState: "true",
+			},
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+
+	r := reconciler.NewReconcilerWith(k8sClient)
+	result, err := r.ReconcileResource(desired, reconciler.StatePresent)
+	if result != nil {
+		t.Fatalf("result expected to be nil if everything went smooth")
+	}
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	desiredMutated := desired.DeepCopy()
+	desiredMutated.Data["a"] = "c"
+
+	nr := reconciler.NewNativeReconcilerWithDefaults("test", k8sClient, clientgoscheme.Scheme, logr.DiscardLogger{}, func(parent reconciler.ResourceOwner, object interface{}) []reconciler.ResourceBuilder {
+		return []reconciler.ResourceBuilder{
+			func() (runtime.Object, reconciler.DesiredState, error) {
+				return desiredMutated, reconciler.DynamicDesiredState{
+					DesiredState: reconciler.StatePresent,
+				}, nil
+			},
+		}
+	}, func() []schema.GroupVersionKind {
+		return nil
+	}, func(_ runtime.Object) (reconciler.ResourceOwner, interface{}) {
+		return nil, nil
+	})
+
+	_, err = nr.Reconcile(desired)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	created := &corev1.ConfigMap{}
+	if err := k8sClient.Get(context.TODO(), utils.ObjectKeyFromObjectMeta(desired), created); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	assert.Equal(t, created.Name, desired.Name)
+	assert.Equal(t, created.Namespace, desired.Namespace)
+	assert.Equal(t, created.Data["a"], desired.Data["a"])
 }
 
 func createReconcilerForRefTests(opts ...reconciler.NativeReconcilerOpt) *reconciler.NativeReconciler {

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -27,10 +27,10 @@ const (
 	ComponentLabel = "app.kubernetes.io/component"
 	ManagedByLabel = "app.kubernetes.io/managed-by"
 
-	BanzaiCloudManagedComponent       = "banzaicloud.io/managed-component"
-	BanzaiCloudOwnedBy                = "banzaicloud.io/owned-by"
-	BanzaiCloudRelatedTo              = "banzaicloud.io/related-to"
-	BanzaiCloudCreateOnlyDesiredState = "banzaicloud.io/create-only-desired-state"
+	BanzaiCloudManagedComponent    = "banzaicloud.io/managed-component"
+	BanzaiCloudOwnedBy             = "banzaicloud.io/owned-by"
+	BanzaiCloudRelatedTo           = "banzaicloud.io/related-to"
+	BanzaiCloudDesiredStateCreated = "banzaicloud.io/desired-state-created"
 )
 
 type ObjectKey struct {

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -27,9 +27,10 @@ const (
 	ComponentLabel = "app.kubernetes.io/component"
 	ManagedByLabel = "app.kubernetes.io/managed-by"
 
-	BanzaiCloudManagedComponent = "banzaicloud.io/managed-component"
-	BanzaiCloudOwnedBy          = "banzaicloud.io/owned-by"
-	BanzaiCloudRelatedTo        = "banzaicloud.io/related-to"
+	BanzaiCloudManagedComponent       = "banzaicloud.io/managed-component"
+	BanzaiCloudOwnedBy                = "banzaicloud.io/owned-by"
+	BanzaiCloudRelatedTo              = "banzaicloud.io/related-to"
+	BanzaiCloudCreateOnlyDesiredState = "banzaicloud.io/create-only-desired-state"
 )
 
 type ObjectKey struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It introduces an annotation (banzaicloud.io/create-only-desired-state) to specify `create-only` desired state for a specific resource. The annotation is only effective if the original desired state is `present`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The primary focus of this feature to support specifying create-only resources using the helm reconciler by simply setting the annotation to "true".
