### PR TITLE
Indent in code

### DIFF
--- a/docs/overrides/override.md
+++ b/docs/overrides/override.md
@@ -21,7 +21,7 @@ Default: -
 
 ### spec (v1.ServiceSpec, optional) {#service-spec}
 
-Kubernetes [Service Specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core)<br>
+Kubernetes [Service Specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core) 
 
 Default: -
 
@@ -49,7 +49,7 @@ Default: -
 
 ### spec (networkingv1beta1.IngressSpec, optional) {#ingressnetworkingv1beta1-spec}
 
-Kubernetes [Ingress Specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclassspec-v1-networking-k8s-io)<br>
+Kubernetes [Ingress Specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclassspec-v1-networking-k8s-io) 
 
 Default: -
 
@@ -64,7 +64,7 @@ Default: -
 
 ### spec (DaemonSetSpec, optional) {#daemonset-spec}
 
-[Local DaemonSet specification](#daemonset-spec)<br>
+[Local DaemonSet specification](#daemonset-spec) 
 
 Default: -
 
@@ -76,31 +76,31 @@ and [PodTemplateSpec replaced by the local variant](#podtemplatespec).
 
 ### selector (*metav1.LabelSelector, optional) {#daemonsetspec-selector}
 
-A label query over pods that are managed by the daemon set.<br>
+A label query over pods that are managed by the daemon set. 
 
 Default: -
 
 ### template (PodTemplateSpec, optional) {#daemonsetspec-template}
 
-An object that describes the pod that will be created. Note that this is a [local PodTemplateSpec](#podtemplatespec)<br>
+An object that describes the pod that will be created. Note that this is a [local PodTemplateSpec](#podtemplatespec) 
 
 Default: -
 
 ### updateStrategy (appsv1.DaemonSetUpdateStrategy, optional) {#daemonsetspec-updatestrategy}
 
-An update strategy to replace existing DaemonSet pods with new pods.<br>
+An update strategy to replace existing DaemonSet pods with new pods. 
 
 Default: -
 
 ### minReadySeconds (int32, optional) {#daemonsetspec-minreadyseconds}
 
-The minimum number of seconds for which a newly created DaemonSet pod should<br>be ready without any of its container crashing, for it to be considered<br>available. Defaults to 0 (pod will be considered available as soon as it<br>is ready). <br>
+The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).  
 
 Default:  0
 
 ### revisionHistoryLimit (*int32, optional) {#daemonsetspec-revisionhistorylimit}
 
-The number of old history to retain to allow rollback.<br>This is a pointer to distinguish between explicit zero and not specified.<br>Defaults to 10. <br>
+The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.  
 
 Default:  10
 
@@ -115,7 +115,7 @@ Default: -
 
 ### spec (DeploymentSpec, optional) {#deployment-spec}
 
-The desired behavior of [this deployment](#deploymentspec).<br>
+The desired behavior of [this deployment](#deploymentspec). 
 
 Default: -
 
@@ -127,49 +127,49 @@ and [PodTemplateSpec replaced by the local variant](#podtemplatespec).
 
 ### replicas (*int32, optional) {#deploymentspec-replicas}
 
-Number of desired pods. This is a pointer to distinguish between explicit<br>zero and not specified. Defaults to 1. <br>
+Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.  
 
 Default:  1
 
 ### selector (*metav1.LabelSelector, optional) {#deploymentspec-selector}
 
-Label selector for pods. Existing ReplicaSets whose pods are<br>selected by this will be the ones affected by this deployment.<br>It must match the pod template's labels.<br>
+Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels. 
 
 Default: -
 
 ### template (PodTemplateSpec, optional) {#deploymentspec-template}
 
-An object that describes the pod that will be created. Note that this is a [local PodTemplateSpec](#podtemplatespec)<br>
+An object that describes the pod that will be created. Note that this is a [local PodTemplateSpec](#podtemplatespec) 
 
 Default: -
 
 ### strategy (appsv1.DeploymentStrategy, optional) {#deploymentspec-strategy}
 
-The deployment strategy to use to replace existing pods with new ones.<br>+patchStrategy=retainKeys<br>
+The deployment strategy to use to replace existing pods with new ones. +patchStrategy=retainKeys 
 
 Default: -
 
 ### minReadySeconds (int32, optional) {#deploymentspec-minreadyseconds}
 
-Minimum number of seconds for which a newly created pod should be ready<br>without any of its container crashing, for it to be considered available.<br>Defaults to 0 (pod will be considered available as soon as it is ready) <br>
+Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)  
 
 Default:  0
 
 ### revisionHistoryLimit (*int32, optional) {#deploymentspec-revisionhistorylimit}
 
-The number of old ReplicaSets to retain to allow rollback.<br>This is a pointer to distinguish between explicit zero and not specified.<br>Defaults to 10. <br>
+The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.  
 
 Default:  10
 
 ### paused (bool, optional) {#deploymentspec-paused}
 
-Indicates that the deployment is paused.<br>
+Indicates that the deployment is paused. 
 
 Default: -
 
 ### progressDeadlineSeconds (*int32, optional) {#deploymentspec-progressdeadlineseconds}
 
-The maximum time in seconds for a deployment to make progress before it<br>is considered to be failed. The deployment controller will continue to<br>process failed deployments and a condition with a ProgressDeadlineExceeded<br>reason will be surfaced in the deployment status. Note that progress will<br>not be estimated during the time a deployment is paused.<br>Defaults to 600s. <br>
+The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.  
 
 Default:  600
 
@@ -194,49 +194,49 @@ and [PodTemplateSpec](#podtemplatespec) and [PersistentVolumeClaim replaced by t
 
 ### replicas (*int32, optional) {#statefulsetspec-replicas}
 
-Replicas is the desired number of replicas of the given Template.<br>These are replicas in the sense that they are instantiations of the<br>same Template, but individual replicas also have a consistent identity.<br>If unspecified, defaults to 1. <br>+optional<br>
+Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.  +optional 
 
 Default:  1
 
 ### selector (*metav1.LabelSelector, optional) {#statefulsetspec-selector}
 
-Selector is a label query over pods that should match the replica count.<br>It must match the pod template's labels.<br>
+Selector is a label query over pods that should match the replica count. It must match the pod template's labels. 
 
 Default: -
 
 ### template (PodTemplateSpec, optional) {#statefulsetspec-template}
 
-template is the object that describes the pod that will be created if<br>insufficient replicas are detected. Each pod stamped out by the StatefulSet<br>will fulfill this Template, but have a unique identity from the rest<br>of the StatefulSet.<br>
+template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet. 
 
 Default: -
 
 ### volumeClaimTemplates ([]PersistentVolumeClaim, optional) {#statefulsetspec-volumeclaimtemplates}
 
-volumeClaimTemplates is a list of claims that pods are allowed to reference.<br>The StatefulSet controller is responsible for mapping network identities to<br>claims in a way that maintains the identity of a pod. Every claim in<br>this list must have at least one matching (by name) volumeMount in one<br>container in the template. A claim in this list takes precedence over<br>any volumes in the template, with the same name.<br>+optional<br>
+volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name. +optional 
 
 Default: -
 
 ### serviceName (string, optional) {#statefulsetspec-servicename}
 
-serviceName is the name of the service that governs this StatefulSet.<br>This service must exist before the StatefulSet, and is responsible for<br>the network identity of the set. Pods get DNS/hostnames that follow the<br>pattern: pod-specific-string.serviceName.default.svc.cluster.local<br>where "pod-specific-string" is managed by the StatefulSet controller.<br>
+serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller. 
 
 Default: -
 
 ### podManagementPolicy (appsv1.PodManagementPolicyType, optional) {#statefulsetspec-podmanagementpolicy}
 
-podManagementPolicy controls how pods are created during initial scale up,<br>when replacing pods on nodes, or when scaling down. The default policy is<br>`OrderedReady`, where pods are created in increasing order (pod-0, then<br>pod-1, etc) and the controller will wait until each pod is ready before<br>continuing. When scaling down, the pods are removed in the opposite order.<br>The alternative policy is `Parallel` which will create pods in parallel<br>to match the desired scale without waiting, and on scale down will delete<br>all pods at once.<br><br>+optional<br>
+podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.  +optional 
 
 Default:  OrderedReady
 
 ### updateStrategy (appsv1.StatefulSetUpdateStrategy, optional) {#statefulsetspec-updatestrategy}
 
-updateStrategy indicates the StatefulSetUpdateStrategy that will be<br>employed to update Pods in the StatefulSet when a revision is made to<br>Template.<br>
+updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template. 
 
 Default: -
 
 ### revisionHistoryLimit (*int32, optional) {#statefulsetspec-revisionhistorylimit}
 
-revisionHistoryLimit is the maximum number of revisions that will<br>be maintained in the StatefulSet's revision history. The revision history<br>consists of all revisions not represented by a currently applied<br>StatefulSetSpec version. The default value is 10. <br>
+revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.  
 
 Default:  10
 
@@ -293,205 +293,205 @@ PodSpec is a subset of [PodSpec in k8s.io/api/corev1](https://kubernetes.io/docs
 
 ### volumes ([]v1.Volume, optional) {#podspec-volumes}
 
-List of volumes that can be mounted by containers belonging to the pod.<br>+patchMergeKey=name<br>+patchStrategy=merge,retainKeys<br>
+List of volumes that can be mounted by containers belonging to the pod. +patchMergeKey=name +patchStrategy=merge,retainKeys 
 
 Default: -
 
 ### initContainers ([]v1.Container, optional) {#podspec-initcontainers}
 
-List of initialization containers belonging to the pod.<br>+patchMergeKey=name<br>+patchStrategy=merge<br>
+List of initialization containers belonging to the pod. +patchMergeKey=name +patchStrategy=merge 
 
 Default: -
 
 ### containers ([]v1.Container, optional) {#podspec-containers}
 
-List of containers belonging to the pod.<br>+patchMergeKey=name<br>+patchStrategy=merge<br>
+List of containers belonging to the pod. +patchMergeKey=name +patchStrategy=merge 
 
 Default: -
 
 ### ephemeralContainers ([]v1.EphemeralContainer, optional) {#podspec-ephemeralcontainers}
 
-List of ephemeral containers run in this pod.<br>+patchMergeKey=name<br>+patchStrategy=merge<br>
+List of ephemeral containers run in this pod. +patchMergeKey=name +patchStrategy=merge 
 
 Default: -
 
 ### restartPolicy (v1.RestartPolicy, optional) {#podspec-restartpolicy}
 
-Restart policy for all containers within the pod.<br>One of Always, OnFailure, Never.<br>Default to Always. <br>
+Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always.  
 
 Default:  Always
 
 ### terminationGracePeriodSeconds (*int64, optional) {#podspec-terminationgraceperiodseconds}
 
-Optional duration in seconds the pod needs to terminate gracefully.<br>Defaults to 30 seconds. <br>
+Optional duration in seconds the pod needs to terminate gracefully. Defaults to 30 seconds.  
 
 Default:  30
 
 ### activeDeadlineSeconds (*int64, optional) {#podspec-activedeadlineseconds}
 
-Optional duration in seconds the pod may be active on the node relative to<br>
+Optional duration in seconds the pod may be active on the node relative to 
 
 Default: -
 
 ### dnsPolicy (v1.DNSPolicy, optional) {#podspec-dnspolicy}
 
-Set DNS policy for the pod.<br>Defaults to "ClusterFirst". <br>Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.<br>
+Set DNS policy for the pod. Defaults to "ClusterFirst".  Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. 
 
 Default:  ClusterFirst
 
 ### nodeSelector (map[string]string, optional) {#podspec-nodeselector}
 
-NodeSelector is a selector which must be true for the pod to fit on a node.<br>
+NodeSelector is a selector which must be true for the pod to fit on a node. 
 
 Default: -
 
 ### serviceAccountName (string, optional) {#podspec-serviceaccountname}
 
-ServiceAccountName is the name of the ServiceAccount to use to run this pod.<br>
+ServiceAccountName is the name of the ServiceAccount to use to run this pod. 
 
 Default: -
 
 ### automountServiceAccountToken (*bool, optional) {#podspec-automountserviceaccounttoken}
 
-AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.<br>
+AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. 
 
 Default: -
 
 ### nodeName (string, optional) {#podspec-nodename}
 
-NodeName is a request to schedule this pod onto a specific node.<br>
+NodeName is a request to schedule this pod onto a specific node. 
 
 Default: -
 
 ### hostNetwork (bool, optional) {#podspec-hostnetwork}
 
-Host networking requested for this pod. Use the host's network namespace.<br>If this option is set, the ports that will be used must be specified.<br>Default to false. <br>
+Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.  
 
 Default:  false
 
 ### hostPID (bool, optional) {#podspec-hostpid}
 
-Use the host's pid namespace.<br>Optional: Default to false. <br>
+Use the host's pid namespace. Optional: Default to false.  
 
 Default:  false
 
 ### hostIPC (bool, optional) {#podspec-hostipc}
 
-Use the host's ipc namespace.<br>Optional: Default to false. <br>
+Use the host's ipc namespace. Optional: Default to false.  
 
 Default:  false
 
 ### shareProcessNamespace (*bool, optional) {#podspec-shareprocessnamespace}
 
-Share a single process namespace between all of the containers in a pod.<br>HostPID and ShareProcessNamespace cannot both be set.<br>Optional: Default to false. <br>
+Share a single process namespace between all of the containers in a pod. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.  
 
 Default:  false
 
 ### securityContext (*v1.PodSecurityContext, optional) {#podspec-securitycontext}
 
-SecurityContext holds pod-level security attributes and common container settings.<br>Optional: Defaults to empty.  See type description for default values of each field.<br>
+SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field. 
 
 Default: -
 
 ### imagePullSecrets ([]v1.LocalObjectReference, optional) {#podspec-imagepullsecrets}
 
-ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.<br>+patchMergeKey=name<br>+patchStrategy=merge<br>
+ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. +patchMergeKey=name +patchStrategy=merge 
 
 Default: -
 
 ### hostname (string, optional) {#podspec-hostname}
 
-Specifies the hostname of the Pod<br>If not specified, the pod's hostname will be set to a system-defined value.<br>
+Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value. 
 
 Default: -
 
 ### subdomain (string, optional) {#podspec-subdomain}
 
-If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".<br>If not specified, the pod will not have a domainname at all.<br>
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all. 
 
 Default: -
 
 ### affinity (*v1.Affinity, optional) {#podspec-affinity}
 
-If specified, the pod's scheduling constraints<br>
+If specified, the pod's scheduling constraints 
 
 Default: -
 
 ### schedulerName (string, optional) {#podspec-schedulername}
 
-If specified, the pod will be dispatched by specified scheduler.<br>If not specified, the pod will be dispatched by default scheduler.<br>
+If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler. 
 
 Default: -
 
 ### tolerations ([]v1.Toleration, optional) {#podspec-tolerations}
 
-If specified, the pod's tolerations.<br>
+If specified, the pod's tolerations. 
 
 Default: -
 
 ### hostAliases ([]v1.HostAlias, optional) {#podspec-hostaliases}
 
-HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts<br>file if specified. This is only valid for non-hostNetwork pods.<br>+patchMergeKey=ip<br>+patchStrategy=merge<br>
+HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods. +patchMergeKey=ip +patchStrategy=merge 
 
 Default: -
 
 ### priorityClassName (string, optional) {#podspec-priorityclassname}
 
-If specified, indicates the pod's priority.<br>
+If specified, indicates the pod's priority. 
 
 Default: -
 
 ### priority (*int32, optional) {#podspec-priority}
 
-The priority value. Various system components use this field to find the<br>priority of the pod.<br>
+The priority value. Various system components use this field to find the priority of the pod. 
 
 Default: -
 
 ### dnsConfig (*v1.PodDNSConfig, optional) {#podspec-dnsconfig}
 
-Specifies the DNS parameters of a pod.<br>
+Specifies the DNS parameters of a pod. 
 
 Default: -
 
 ### readinessGates ([]v1.PodReadinessGate, optional) {#podspec-readinessgates}
 
-If specified, all readiness gates will be evaluated for pod readiness.<br>
+If specified, all readiness gates will be evaluated for pod readiness. 
 
 Default: -
 
 ### runtimeClassName (*string, optional) {#podspec-runtimeclassname}
 
-RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used<br>to run this pod.<br>
+RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod. 
 
 Default: -
 
 ### enableServiceLinks (*bool, optional) {#podspec-enableservicelinks}
 
-EnableServiceLinks indicates whether information about services should be injected into pod's<br>environment variables, matching the syntax of Docker links.<br>Optional: Defaults to true. <br>
+EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.  
 
 Default:  true
 
 ### preemptionPolicy (*v1.PreemptionPolicy, optional) {#podspec-preemptionpolicy}
 
-PreemptionPolicy is the Policy for preempting pods with lower priority.<br>One of Never, PreemptLowerPriority.<br>Defaults to PreemptLowerPriority if unset. <br>
+PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.  
 
 Default:  PreemptLowerPriority
 
 ### overhead (v1.ResourceList, optional) {#podspec-overhead}
 
-Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.<br>
+Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. 
 
 Default: -
 
 ### topologySpreadConstraints ([]v1.TopologySpreadConstraint, optional) {#podspec-topologyspreadconstraints}
 
-TopologySpreadConstraints describes how a group of pods ought to spread across topology<br>domains.<br>+patchMergeKey=topologyKey<br>+patchStrategy=merge<br>+listType=map<br>+listMapKey=topologyKey<br>+listMapKey=whenUnsatisfiable<br>
+TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. +patchMergeKey=topologyKey +patchStrategy=merge +listType=map +listMapKey=topologyKey +listMapKey=whenUnsatisfiable 
 
 Default: -
 
 ### setHostnameAsFQDN (*bool, optional) {#podspec-sethostnameasfqdn}
 
-If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).<br>Default to false. <br>+optional<br>
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). Default to false.  +optional 
 
 Default:  false
 
@@ -502,25 +502,25 @@ ServiceAccount is a subset of [ServiceAccount in k8s.io/api/core/v1](https://kub
 
 ### metadata (ObjectMeta, optional) {#serviceaccount-metadata}
 
-+optional<br>
++optional 
 
 Default: -
 
 ### secrets ([]v1.ObjectReference, optional) {#serviceaccount-secrets}
 
-+optional<br>+patchMergeKey=name<br>+patchStrategy=merge<br>
++optional +patchMergeKey=name +patchStrategy=merge 
 
 Default: -
 
 ### imagePullSecrets ([]v1.LocalObjectReference, optional) {#serviceaccount-imagepullsecrets}
 
-+optional<br>
++optional 
 
 Default: -
 
 ### automountServiceAccountToken (*bool, optional) {#serviceaccount-automountserviceaccounttoken}
 
-+optional<br>
++optional 
 
 Default: -
 

--- a/docs/types/secret_types.md
+++ b/docs/types/secret_types.md
@@ -9,19 +9,19 @@
 
 ### value (string, optional) {#secret-value}
 
-Refers to a non-secret value<br>
+Refers to a non-secret value 
 
 Default: -
 
 ### valueFrom (*ValueFrom, optional) {#secret-valuefrom}
 
-Refers to a secret value to be used directly<br>
+Refers to a secret value to be used directly 
 
 Default: -
 
 ### mountFrom (*ValueFrom, optional) {#secret-mountfrom}
 
-Refers to a secret value to be used through a volume mount<br>
+Refers to a secret value to be used through a volume mount 
 
 Default: -
 

--- a/docs/types/volume_types.md
+++ b/docs/types/volume_types.md
@@ -9,7 +9,7 @@
 
 ### host_path (*corev1.HostPathVolumeSource, optional) {#kubernetesvolume-host_path}
 
-Deprecated, use hostPath<br>
+Deprecated, use hostPath 
 
 Default: -
 
@@ -23,7 +23,7 @@ Default: -
 
 ### pvc (*PersistentVolumeClaim, optional) {#kubernetesvolume-pvc}
 
-PersistentVolumeClaim defines the Spec and the Source at the same time.<br>The PVC will be created with the configured spec and the name defined in the source.<br>
+PersistentVolumeClaim defines the Spec and the Source at the same time. The PVC will be created with the configured spec and the name defined in the source. 
 
 Default: -
 

--- a/pkg/docgen/docgen_test.go
+++ b/pkg/docgen/docgen_test.go
@@ -72,6 +72,31 @@ func TestGenParse(t *testing.T) {
 				Default: testval
 			`),
 		},
+		{
+			docItem: docgen.DocItem{
+				Name:       "sample-codeblock",
+				SourcePath: filepath.Join(currentDir, "testdata", "sample_codeblock.go"),
+				DestPath:   filepath.Join(currentDir, "../../build/_test/docgen"),
+				DefaultValueFromTagExtractor: func(tag string) string {
+					return docgen.GetPrefixedValue(tag, `asd:\"default:(.*)\"`)
+				},
+			},
+			expected: heredoc.Doc(`
+				## Sample
+
+				### field1 (string, optional) {#sample-field1}
+
+				Description
+				{{< highlight yaml >}}
+				test: code block
+				some: more lines
+					indented: line
+				{{< /highlight >}}
+
+
+				Default: -
+			`),
+		},
 	}
 
 	for _, item := range testData {

--- a/pkg/docgen/testdata/sample_codeblock.go
+++ b/pkg/docgen/testdata/sample_codeblock.go
@@ -1,0 +1,26 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+type Sample struct {
+	// Description
+	//
+	// {{< highlight yaml >}}
+	// test: code block
+	// some: more lines
+	//     indented: line
+	// {{< /highlight >}}
+	Field1 string `json:"field1,omitempty"`
+}


### PR DESCRIPTION
Makes it possible to add code samples in the doc comments that become highlighted code blocks in hugo, and keep the indentation

(Probably could be done for code fenced between ```, but that's more tricky)

For example: 
	// The minimum number of seconds for which a newly created DaemonSet pod should
	// be ready without any of its container crashing, for it to be considered
	// available. Defaults to 0 (pod will be considered available as soon as it
	// is ready). (default: 0)
	//
	// {{< highlight yaml >}}
	// test: multiline docstring
	// some: more lines
	//     indented: line
	// {{< /highlight >}}
	// some more docs

becomes:

The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).   
{{< highlight yaml >}}
test: multiline docstring
some: more lines
    indented: line
{{< /highlight >}}
some more docs

Note: the test is not working yet, as it doesn't fail if the indentation changes.
