### PR TITLE
Remove parent owners

### DIFF
--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -214,7 +214,6 @@ func (c *Inventory) PrepareDesiredObjects(ns, componentName string, parent recon
 	// create inventory of created objects
 	if newInventory, err := CreateObjectsInventory(ns, objectsInventoryName, desiredObjects); err == nil {
 		c.inventoryData.DesiredObjects = desiredObjects
-		newInventory.SetOwnerReferences(parent.GetOwnerReferences())
 		return newInventory, nil
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

An object can't have multiple owners with type `controller`:

```
Object x/y is already owned by another ControlPlane controller z
```