### PR TITLE
Allow configurable propagation for Replacement delete.

### DIFF
--- a/pkg/reconciler/resource.go
+++ b/pkg/reconciler/resource.go
@@ -172,9 +172,6 @@ func NewGenericReconciler(c client.Client, log logr.Logger, opts ReconcilerOpts)
 	if opts.RecreateEnabledResourceCondition == nil {
 		// only allow a custom set of types and only specific errors
 		opts.RecreateEnabledResourceCondition = func(kind schema.GroupVersionKind, status metav1.Status) bool {
-			if !strings.Contains(status.Message, *opts.RecreateErrorMessageSubstring) {
-				return false
-			}
 			for _, gk := range DefaultRecreateEnabledGroupKinds {
 				if gk == kind.GroupKind() {
 					return true

--- a/pkg/reconciler/resource.go
+++ b/pkg/reconciler/resource.go
@@ -150,13 +150,15 @@ type ReconcilerOpts struct {
 	RecreateEnabledResourceCondition RecreateResourceCondition
 	// Immediately recreate the resource instead of deleting and returning with a requeue
 	RecreateImmediately bool
+	// Configure the recreate PropagationPolicy. "Orphan" avoids deleting pods simultaneously.
+	RecreatePropagationPolicy client.PropagationPolicy
 	// Check the update error message contains this substring before recreate. Default: "immutable"
 	RecreateErrorMessageSubstring *string
 }
 
 // NewGenericReconciler returns GenericResourceReconciler
 // Deprecated, use NewReconcilerWith
-func NewGenericReconciler(client client.Client, log logr.Logger, opts ReconcilerOpts) *GenericResourceReconciler {
+func NewGenericReconciler(c client.Client, log logr.Logger, opts ReconcilerOpts) *GenericResourceReconciler {
 	if opts.Scheme == nil {
 		opts.Scheme = runtime.NewScheme()
 		_ = clientgoscheme.AddToScheme(opts.Scheme)
@@ -181,9 +183,13 @@ func NewGenericReconciler(client client.Client, log logr.Logger, opts Reconciler
 			return false
 		}
 	}
+	if len(opts.RecreatePropagationPolicy) == 0 {
+		// DO NOT wait until all dependent resources get cleared up
+		opts.RecreatePropagationPolicy = client.PropagationPolicy(metav1.DeletePropagationBackground)
+	}
 	return &GenericResourceReconciler{
 		Log:     log,
-		Client:  client,
+		Client:  c,
 		Options: opts,
 	}
 }
@@ -405,8 +411,7 @@ func (r *GenericResourceReconciler) ReconcileResource(desired runtime.Object, de
 					log.Error(err, "failed to update resource, trying to recreate", resourceDetails...)
 					if r.Options.RecreateImmediately {
 						err := r.Client.Delete(context.TODO(), current.(client.Object),
-							// DO NOT wait until all dependent resources get cleared up
-							client.PropagationPolicy(metav1.DeletePropagationBackground),
+							r.Options.RecreatePropagationPolicy,
 						)
 						if err != nil {
 							return nil, errors.WrapIfWithDetails(err, "failed to delete current resource", resourceDetails...)

--- a/pkg/reconciler/resource.go
+++ b/pkg/reconciler/resource.go
@@ -172,7 +172,7 @@ func NewGenericReconciler(c client.Client, log logr.Logger, opts ReconcilerOpts)
 	if opts.RecreateEnabledResourceCondition == nil {
 		// only allow a custom set of types and only specific errors
 		opts.RecreateEnabledResourceCondition = func(kind schema.GroupVersionKind, status metav1.Status) bool {
-			if !strings.Contains(status.Message, "immutable") {
+			if !strings.Contains(status.Message, *opts.RecreateErrorMessageSubstring) {
 				return false
 			}
 			for _, gk := range DefaultRecreateEnabledGroupKinds {


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There is code to replace resources that can't be updated do to immutable fields, which is handy.

However, replacing a StatefulSet because of immutable fields WITH propagation deletes all the pods.

It does not obey the UpdateStrategy or respect a PodDisruptionBudget, causing downtime.

**Describe the solution you'd like to see**
Either automatically choose "Orphan" propagation when appropriate or allow users to provide the policy.

These are the additional opts I have configured to make STS replacement work with this change:

```go
recreateErrorMessageSubstring := "Forbidden: updates to statefulset spec for fields other than"
o.RecreateErrorMessageSubstring = &recreateErrorMessageSubstring
o.EnableRecreateWorkloadOnImmutableFieldChange = true
o.RecreatePropagationPolicy = client.PropagationPolicy(metav1.DeletePropagationOrphan)
```

**Describe alternatives you've considered**
Haven't thought of alternatives that work will. BeforeUpdate will let me hook into this, but I can't do much about it without causing at least 1 reconcile error.

**Additional context**
https://github.com/banzaicloud/operator-tools/blob/3b2be81729c1fa8852c12e4d66c81ff34a339357/pkg/reconciler/resource.go#L406-L410
