### PR TITLE
Dispatcher: use reverse order for deletion

### DIFF
--- a/pkg/resources/object.go
+++ b/pkg/resources/object.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -159,4 +160,15 @@ func (p *ObjectParser) removeNonYAMLLines(yms string) string {
 	}
 
 	return strings.TrimSpace(out)
+}
+
+// IsObjectBeingDeleted returns true, if the given object is being deleted with finalizers still
+// existing on it (this is the only case when deleteion timestamp is non-zero)
+func IsObjectBeingDeleted(object runtime.Object) (bool, error) {
+	objMeta, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+
+	return !objMeta.GetDeletionTimestamp().IsZero(), nil
 }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?

This patch adds support for executing the components of the Dispatcher
object in reverse order in case the object is being deleted (e.g. it has
a finalizer and a delete has been called on it).

The motivation behind is that when uninstalling a multi component object
the components might depend on each other (e.g. first you install
prometheus-operator, then the services require the the operator). In
such a setup the uninstallation should happen in reverse order to be
correct.

