### PR TITLE
Make the getFiles call public to reuse from downstream packages

### DIFF
--- a/pkg/helm/render.go
+++ b/pkg/helm/render.go
@@ -62,7 +62,7 @@ func GetDefaultValues(fs http.FileSystem) ([]byte, error) {
 }
 
 func Render(fs http.FileSystem, values map[string]interface{}, releaseOptions ReleaseOptions, chartName string) ([]runtime.Object, error) {
-	files, err := getFiles(fs)
+	files, err := GetFiles(fs)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func parseAndAppendObjects(parser func([]byte) (runtime.Object, error), objects 
 	return objects, nil
 }
 
-func getFiles(fs http.FileSystem) ([]*loader.BufferedFile, error) {
+func GetFiles(fs http.FileSystem) ([]*loader.BufferedFile, error) {
 	files := []*loader.BufferedFile{
 		{
 			Name: chartutil.ChartfileName,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Make the GetFiles public, to allow downstream consumers using it.


### Why?
It comes handy when the chart content that was embedded and represented as an http.Filesystem object need to be restored in a downstream project.
