### PR TITLE
Fix merge function to unmarshal results into an externally provided object

### DIFF
--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -23,7 +23,7 @@ import (
 // Merge merges `overrides` into `base` using the SMP (structural merge patch) approach.
 // - It intentionally does not remove fields present in base but missing from overrides
 // - It merges slices only if the `patchStrategy:"merge"` tag is present and the `patchMergeKey` identifies the unique field
-func Merge(base, overrides interface{}) error {
+func Merge(base, overrides, into interface{}) error {
 	baseBytes, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(base)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert current object to byte sequence")
@@ -48,5 +48,5 @@ func Merge(base, overrides interface{}) error {
 		return errors.WrapIf(err, "failed to apply patch")
 	}
 
-	return jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(merged, base)
+	return jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(merged, into)
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| License         | Apache 2.0


### What's in this PR?
This is a breaking change that requires an additional argument for the Merge function to pass an object that will be populated with merge results, instead of unmarshaling back into the original base object.

### Why?
The problem with the original approach was that unmarshaling into the base does not simply apply the merged value over the original, but performs an additional deep merge and does not take the patchMergeKey into account when merging slices.

