### PR TITLE
Fix merge by replacing base with a new value rather than unmarshaling into it directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/iancoleman/orderedmap v0.2.0
-	github.com/json-iterator/go v1.1.11
 	github.com/pborman/uuid v1.2.1
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Replaces #78 using a different approach. Reflect is used to replace the value behind the incoming base pointer to avoid breaking the interface.