### PR TITLE
define EnabledComponent type

### DIFF
--- a/docs/types/base_types.md
+++ b/docs/types/base_types.md
@@ -9,6 +9,16 @@ Default: -
 Default: -
 
 
+## EnabledComponent
+
+EnabledComponent implements the "enabled component" pattern
+Embed this type into other component types to avoid unnecessary code duplication
+
+### enabled (*bool, optional) {#enabledcomponent-enabled}
+
+Default: -
+
+
 ## MetaBase
 
 Deprecated

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -18,6 +18,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/banzaicloud/operator-tools/pkg/utils"
 )
 
 const (
@@ -100,6 +102,27 @@ func AggregatedState(componentStatuses []ReconcileStatus) ReconcileStatus {
 		overallStatus = ReconcileStatusSucceeded
 	}
 	return overallStatus
+}
+
+// EnabledComponent implements the "enabled component" pattern
+// Embed this type into other component types to avoid unnecessary code duplication
+type EnabledComponent struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// IsDisabled returns true iff the component is explicitly disabled
+func (ec EnabledComponent) IsDisabled() bool {
+	return ec.Enabled != nil && !*ec.Enabled
+}
+
+// IsEnabled returns true iff the component is explicitly enabled
+func (ec EnabledComponent) IsEnabled() bool {
+	return utils.PointerToBool(ec.Enabled)
+}
+
+// IsSkipped returns true iff the component is neither enabled nor disabled explicitly
+func (ec EnabledComponent) IsSkipped() bool {
+	return ec.Enabled == nil
 }
 
 // +kubebuilder:object:generate=true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
A type that can be embedded into component (spec) definitions to avoid code duplication.

### Why?
Most (if not all) component (spec) types implement the "enabled component" pattern which results in the same code (`IsEnabled`, `IsSkipped` methods) being duplicated everywhere. By embedding this type into components, implementing the pattern becomes a *one-liner*.
