### PR TITLE
add note to EnabledComponent's docstring about usage with controller-gen

### DIFF
--- a/docs/types/base_types.md
+++ b/docs/types/base_types.md
@@ -13,6 +13,7 @@ Default: -
 
 EnabledComponent implements the "enabled component" pattern
 Embed this type into other component types to avoid unnecessary code duplication
+NOTE: Don't forget to annotate the embedded field with `json:",inline"` tag for controller-gen
 
 ### enabled (*bool, optional) {#enabledcomponent-enabled}
 

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -108,6 +108,7 @@ func AggregatedState(componentStatuses []ReconcileStatus) ReconcileStatus {
 
 // EnabledComponent implements the "enabled component" pattern
 // Embed this type into other component types to avoid unnecessary code duplication
+// NOTE: Don't forget to annotate the embedded field with `json:",inline"` tag for controller-gen
 type EnabledComponent struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
Add note to `EnabledComponent` type's docstring about suggested annotation when embedding in types processed by controller-gen.

### Why?
Without the annotation, controller-gen fails to process the type.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
