### PR TITLE
Separate license check to GHA for pull requests and on master builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download license information for dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make license-cache
+
+      - name: Check licenses
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make license-check

--- a/.idea/operator-tools.iml
+++ b/.idea/operator-tools.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ bin/licensei-${LICENSEI_VERSION}:
 	curl -sfL https://git.io/licensei | bash -s v${LICENSEI_VERSION}
 	@mv bin/licensei $@
 
+.PHONY: license-cache
+license-cache: bin/licensei ## Generate license cache
+	bin/licensei cache
+
 .PHONY: license-check
 license-check: bin/licensei ## Run license check
 	bin/licensei check
@@ -67,7 +71,7 @@ test: bin/kubebuilder
 	go test ./...
 
 .PHONY: check
-check: test lint license-check check-diff ## Run tests and linters
+check: test lint check-diff ## Run tests and linters
 
 bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This makes external PR's buildable, because right now they fail on license check, which requires a github token. Github Actions use a temporary token which is a better alternative.
