### PR TITLE
support retry on resource reconcile error in native reconciler

### DIFF
--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-type Backoff wait.Backoff
+type Backoff = wait.Backoff
 
 type ResourceConditionChecks struct {
 	client  client.Client
@@ -69,7 +69,6 @@ func (c *ResourceConditionChecks) WaitForCustomConditionChecks(id string, checkF
 
 		return true, nil
 	})
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add support for retry on resource reconcile error in native reconciler.

The following new options were added to native reconciler:

```
NativeReconcilerWithRetriableErrorFunc
NativeReconcilerWithRetryBackoff
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The main reason for this feature is to gracefully handle situations where multiple controllers try to update the same resource and a conflict happens.

The following option can be used to handle that particular issue:

```
reconciler.NativeReconcilerWithRetriableErrorFunc(errors.IsConflict)
```
