### PR TITLE
Skip inventory configmap if namespace is under deletion

### DIFF
--- a/pkg/helm/templatereconciler/reconciler.go
+++ b/pkg/helm/templatereconciler/reconciler.go
@@ -293,11 +293,9 @@ func (rec *HelmReconciler) GetResourceBuilders(parent reconciler.ResourceOwner, 
 				return nil, err
 			}
 		}
-	} else {
-		if doInventory {
-			if resourceBuilders, err = rec.inventory.Append(releaseData.Namespace, releaseData.ReleaseName, parent, resourceBuilders); err != nil {
-				return nil, err
-			}
+	} else if doInventory {
+		if resourceBuilders, err = rec.inventory.Append(releaseData.Namespace, releaseData.ReleaseName, parent, resourceBuilders); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/helm/templatereconciler/reconciler.go
+++ b/pkg/helm/templatereconciler/reconciler.go
@@ -289,11 +289,15 @@ func (rec *HelmReconciler) GetResourceBuilders(parent reconciler.ResourceOwner, 
 
 		resourceBuilders = append(resourceBuilders, chartResourceBuilders...)
 		if doInventory {
-			resourceBuilders = rec.inventory.Append(releaseData.Namespace, releaseData.ReleaseName, parent, resourceBuilders)
+			if resourceBuilders, err = rec.inventory.Append(releaseData.Namespace, releaseData.ReleaseName, parent, resourceBuilders); err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		if doInventory {
-			resourceBuilders = rec.inventory.Append(releaseData.Namespace, releaseData.ReleaseName, parent, resourceBuilders)
+			if resourceBuilders, err = rec.inventory.Append(releaseData.Namespace, releaseData.ReleaseName, parent, resourceBuilders); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -371,12 +371,24 @@ func (c *Inventory) ensureNamespace(namespace string, objects []runtime.Object) 
 	return nil
 }
 
-func (i *Inventory) Append(namespace, component string, parent reconciler.ResourceOwner, resourceBuilders []reconciler.ResourceBuilder) []reconciler.ResourceBuilder {
-	if objectInventory, err := i.PrepareDesiredObjects(namespace, component, parent, resourceBuilders); err == nil {
-		err := i.PrepareDeletableObjects()
-		resourceBuilders = append(resourceBuilders, func() (runtime.Object, reconciler.DesiredState, error) {
-			return objectInventory, reconciler.StatePresent, err
-		})
+func (i *Inventory) Append(namespace, component string, parent reconciler.ResourceOwner, resourceBuilders []reconciler.ResourceBuilder) ([]reconciler.ResourceBuilder, error) {
+	ns := &core.Namespace{}
+	var err error
+	// get the namespace so that we can see if it's under deletion
+	// we don't care if the namespace does not exist, we might be preparing to run this for the first time
+	if err := i.genericClient.Get(context.TODO(), client.ObjectKey{Name: namespace}, ns); client.IgnoreNotFound(err) != nil {
+		return resourceBuilders, err
 	}
-	return resourceBuilders
+	if objectInventory, err := i.PrepareDesiredObjects(namespace, component, parent, resourceBuilders); err == nil {
+		if err := i.PrepareDeletableObjects(); err != nil {
+			return resourceBuilders, err
+		}
+		// do not try to create the inventory when the namespace is being deleted
+		if ns.GetDeletionTimestamp() == nil {
+			resourceBuilders = append(resourceBuilders, func() (runtime.Object, reconciler.DesiredState, error) {
+				return objectInventory, reconciler.StatePresent, err
+			})
+		}
+	}
+	return resourceBuilders, err
 }

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -384,7 +384,7 @@ func (i *Inventory) Append(namespace, component string, parent reconciler.Resour
 			return resourceBuilders, err
 		}
 		// do not try to create the inventory when the namespace is being deleted
-		if ns.GetDeletionTimestamp() == nil {
+		if ns.GetDeletionTimestamp().IsZero() {
 			resourceBuilders = append(resourceBuilders, func() (runtime.Object, reconciler.DesiredState, error) {
 				return objectInventory, reconciler.StatePresent, err
 			})


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix the `Inventory` to avoid creating the inventory configmap if the namespace is being deleted, since that will always raise an error that would otherwise be avoidable.

Also return with the error from the `Inventory.Append` method.
