### PR TITLE
Fix logsink addvalues

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -85,9 +85,8 @@ func (log *logger) WithName(name string) Logger {
 
 func (log *logger) WithValues(keysAndValues ...interface{}) Logger {
 	sink := log.sink.copyLogger()
-	for k, v := range keysAndValues {
-		sink.values[k] = v
-	}
+
+	sink.values = keysAndValues
 
 	return &logger{
 		level: log.level,

--- a/pkg/logger/logsink.go
+++ b/pkg/logger/logsink.go
@@ -223,9 +223,7 @@ func (log *SpinnerLogSink) GetValues() []interface{} {
 }
 
 func (log *SpinnerLogSink) AddValues(keyAndValues []interface{}) {
-	for k, v := range keyAndValues {
-		log.values[k] = v
-	}
+	log.values = append(log.values, keyAndValues...)
 }
 
 func (log *SpinnerLogSink) AddName(name string) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #108 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix to panic issue due to array element assignment with no allocation in SpinnerLogSink.AddValues() and logger.WithValues()

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Array bounds issue for SpinnerLogSink.values due to no alloc

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

