### PR TITLE
Imps override fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CONTROLLER_GEN = $(PWD)/bin/controller-gen
 OS = $(shell uname | tr A-Z a-z)
 
 ENVTEST_BIN_DIR := ${BIN}/envtest
-ENVTEST_K8S_VERSION := 1.23.1
+ENVTEST_K8S_VERSION := 1.24.1
 ENVTEST_BINARY_ASSETS := ${ENVTEST_BIN_DIR}/bin
 
 SETUP_ENVTEST := ${BIN}/setup-envtest
@@ -34,11 +34,7 @@ generate: bin/controller-gen
 bin/controller-gen:
 	@ if ! test -x bin/controller-gen; then \
 		set -ex ;\
-		CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-		cd $$CONTROLLER_GEN_TMP_DIR ;\
-		go mod init tmp ;\
-		GOBIN=$(PWD)/bin go get sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} ;\
-		rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+		GOBIN=$(PWD)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} ;\
 	fi
 
 

--- a/pkg/types/base_types.go
+++ b/pkg/types/base_types.go
@@ -291,6 +291,10 @@ func (base *PodSpecBase) Override(spec corev1.PodSpec) corev1.PodSpec {
 			}
 		}
 	}
+
+	spec.ImagePullSecrets = append(([]corev1.LocalObjectReference)(nil), spec.ImagePullSecrets...)
+	spec.ImagePullSecrets = append(spec.ImagePullSecrets, base.ImagePullSecrets...)
+
 	return spec
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
ImagePullSecrets weren't applied when overriding podspec via PodSpecBase.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
